### PR TITLE
Gtx monitor from evaldas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+setup_here.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
-setup_here.sh
+# localized source script 
+/setup_here.sh
+# build logs
+/*.log
+# emacs stuff
+*~
+# xdaq build directories, hopefully globs are enough
+lib/
+linux/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 # xdaq build directories, hopefully globs are enough
 lib/
 linux/
+#svn stuff
+.svn/
+# developer tools stuff
+semantic.cache
+nbproject/

--- a/emuDCS/PeripheralApps/include/emu/pc/EmuPeripheralCrateCommand.h
+++ b/emuDCS/PeripheralApps/include/emu/pc/EmuPeripheralCrateCommand.h
@@ -273,7 +273,8 @@ protected:
   unsigned int total_crates_;
   int this_crate_no_;
   std::string ThisCrateID_;
-  
+  int MPClist_;
+    
   bool Monitor_On_, Monitor_Ready_;
   //
   bool ccb_checked_;
@@ -315,7 +316,9 @@ private:
   xoap::MessageReference onEnableCalALCTConnectivity (xoap::MessageReference message) throw (xoap::exception::Exception);
   xoap::MessageReference onEnableCalALCTThresholds (xoap::MessageReference message) throw (xoap::exception::Exception);
   xoap::MessageReference onEnableCalALCTDelays (xoap::MessageReference message) throw (xoap::exception::Exception);
-  // ---
+
+  // MPC-TF test
+  xoap::MessageReference onFillMPCFIFOAs (xoap::MessageReference message) throw (xoap::exception::Exception);  
 
   void configureAction(toolbox::Event::Reference e) throw (toolbox::fsm::exception::Exception); 
   void configureFail(toolbox::Event::Reference e) throw (toolbox::fsm::exception::Exception); 
@@ -329,6 +332,9 @@ private:
   void CheckCrates(xgi::Input * in, xgi::Output * out ) throw (xgi::exception::Exception); 
   void CheckCratesConfiguration(xgi::Input * in, xgi::Output * out ) throw (xgi::exception::Exception); 
   void CheckCrateConfiguration(xgi::Input * in, xgi::Output * out ) throw (xgi::exception::Exception); 
+
+  void ReadMPCFIFOBOld(xgi::Input * in, xgi::Output * out ) throw (xgi::exception::Exception); 
+  void ReadMPCFIFOBNew(xgi::Input * in, xgi::Output * out ) throw (xgi::exception::Exception); 
 
   void ResetAllTMBCounters();
   int VerifyCratesConfiguration();

--- a/emuDCS/PeripheralApps/include/emu/pc/EmuPeripheralCrateConfig.h
+++ b/emuDCS/PeripheralApps/include/emu/pc/EmuPeripheralCrateConfig.h
@@ -44,6 +44,7 @@
 #include "emu/pc/Crate.h"
 #include "emu/pc/DAQMB.h"
 #include "emu/pc/TMB.h"
+#include "emu/pc/TMB_constants.h"
 #include "emu/pc/TMBTester.h"
 #include "emu/pc/CCB.h"
 #include "emu/pc/MPC.h"

--- a/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
+++ b/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
@@ -3160,6 +3160,8 @@ int ChamberUtilities::ALCTBC0Scan() {
   int initial_bxn_offset         = thisTMB->GetBxnOffset();
   //
   //
+  local_tmb_bxn_offset_=initial_bxn_offset;
+
   if (debug_>=10) {
     std::cout << "Initial values..." << std::endl;
     std::cout << "-> initial_mpc_idle_blank    = " << initial_mpc_idle_blank    << std::endl;
@@ -3181,6 +3183,7 @@ int ChamberUtilities::ALCTBC0Scan() {
   (*MyOutput_) << "alct_tof_delay          = 0x" << std::hex << thisTMB->GetAlctTOFDelay() << std::endl;
   (*MyOutput_) << "tmb_to_alct_data_delay  = 0x" << std::hex << thisTMB->GetALCTTxDataDelay() << std::endl;
   //
+
   // Set up for this test:
   // turn off the one shot L1A (from TMB)...
   thisTMB->SetFireL1AOneshot(0);

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig_CCBMPC.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig_CCBMPC.cc
@@ -602,8 +602,8 @@ void EmuPeripheralCrateConfig::MPCUtils(xgi::Input * in, xgi::Output * out )
   *out << cgicc::input().set("type","radio").set("name","newPRBS").set("value", "3") << "PRBS-23";
   *out << cgicc::input().set("type","radio").set("name","newPRBS").set("value", "4") << "PRBS-31";
   *out << cgicc::input().set("type","submit").set("value","Select MPC new links PRBS mode") << std::endl ;
-  *out << cgicc::form() << std::endl ;
   }
+  *out << cgicc::form() << std::endl ;
   //
   
 

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig_CCBMPC.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig_CCBMPC.cc
@@ -177,6 +177,25 @@ void EmuPeripheralCrateConfig::CCBUtils(xgi::Input * in, xgi::Output * out )
   SignalName.push_back("DMB soft reset");
   SignalName.push_back("TMB soft reset");
   SignalName.push_back("MPC soft reset");  // 1F
+  SignalName.push_back(" ");
+  SignalName.push_back(" ");
+  SignalName.push_back(" ");
+  SignalName.push_back(" ");
+  SignalName.push_back("Inject from TMBs");  //24
+  SignalName.push_back("ALCT ADB pulse ");   //25
+  SignalName.push_back(" ");  
+  SignalName.push_back(" ");
+  SignalName.push_back(" ");
+  SignalName.push_back(" ");
+  SignalName.push_back(" ");
+  SignalName.push_back(" ");
+  SignalName.push_back(" ");
+  SignalName.push_back(" ");
+  SignalName.push_back(" ");
+  SignalName.push_back("Inject from SP ");   // 2F
+  SignalName.push_back("Inject from MPC ");   // 30
+  SignalName.push_back("Inject from MS ");   // 31
+  SignalName.push_back("Bounch Count Reset");   // 32
 
   sprintf(Name,"CCB utilities, crate=%s, slot=%d",ThisCrateID_.c_str(),thisCCB->slot());
   //

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig_DMB.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig_DMB.cc
@@ -3658,7 +3658,22 @@ void EmuPeripheralCrateConfig::DMBPrintCounters(xgi::Input * in, xgi::Output * o
     DAQMB * thisDMB = dmbVector[dmb];
     //
     thisDMB->RedirectOutput(&std::cout);
-    thisDMB->PrintCounters(1);
+//    thisDMB->PrintCounters(1);
+      std::vector <CFEB> thisCFEBs=thisDMB->cfebs();
+      for (unsigned i=0;i<thisCFEBs.size();i++) {
+         int ival = 12;
+         std::cout << "laba diena: " << thisDMB->autoload_select_readback_wrd(thisCFEBs[i], ival) << std::endl;
+         //std::cout << "laba diena: " << thisDMB->autoload_select_readback_wrd(thisCFEBs[i], ival) << std::endl;
+	 //std::cout << ival << std::endl;
+	 //thisDMB->Set_TMB_TX_MODE(thisCFEBs[i], 1);
+         //std::cout << "laba diena dar: " << thisDMB->autoload_select_readback_wrd(thisCFEBs[i], ival) << std::endl;
+         //std::cout << "laba diena dar: " << thisDMB->autoload_select_readback_wrd(thisCFEBs[i], ival) << std::endl;
+	 //thisDMB->Set_TMB_TX_MODE(thisCFEBs[i], 0);
+         //std::cout << "laba diena ir dar: " << thisDMB->autoload_select_readback_wrd(thisCFEBs[i], ival) << std::endl;
+         //std::cout << "laba diena ir dar: " << thisDMB->autoload_select_readback_wrd(thisCFEBs[i], ival) << std::endl;
+      }
+
+
     thisDMB->RedirectOutput(&std::cout);
     //
     this->DMBUtils(in,out);

--- a/emuDCS/PeripheralCore/include/emu/pc/DAQMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/DAQMB.h
@@ -803,9 +803,11 @@ public:
   inline void set_chan_kill(int ichan,int chan[16]) { chan[ichan]=KILL_CHAN; }
   void chan2shift(int chan[16],unsigned int shft_bits[3]);
   void set_dcfeb_parambuffer(CFEB &cfeb, unsigned short int bufload[34]);
-  void autoload_select_readback_wrd(CFEB &cfeb, int ival);
+  unsigned autoload_select_readback_wrd(CFEB &cfeb, int ival);
   void autoload_readback_wrd(CFEB &cfeb, char wrd[2]);
-  
+  void  Set_TMB_TX_MODE(CFEB &cfeb,int mode); 
+  DEVTYPE dscamDevice(int cfebNum) const {return (DEVTYPE) (F1DCFEBM+cfebNum);}
+
   // various delays in ODMB
   inline void odmb_set_LCT_L1A_delay(int delay) { WriteRegister(LCT_L1A_DLY, delay&0x3F); }  // 6 bits
   inline void odmb_set_TMB_delay(int delay) { WriteRegister(TMB_DLY, delay&0x3F); }  // 6 bits

--- a/emuDCS/PeripheralCore/include/emu/pc/MPC.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/MPC.h
@@ -232,6 +232,9 @@ class MPC : public VMEModule, public EmuLogger {
   void check_generation();
   int readDSN(void *data);
   int newPRBS(int mode);
+  void Fill_FIFO_A();
+  int Read_FIFO_B_Old(int link, unsigned short *data);
+  int Read_FIFO_B_New(int link, unsigned short *data);
 
  protected:
   /// MPC base address should always correspond to VME Slot 12 (=0x600000)
@@ -245,6 +248,8 @@ class MPC : public VMEModule, public EmuLogger {
     FIFO_A9a = 0xA0, FIFO_A9b = 0xA2, 
     /// FIFOs Bx correspond to the x-th best selected LCT
     FIFO_B1  = 0xA4, FIFO_B2  = 0xA6, FIFO_B3  = 0xA8,
+    /// FIFO_Bx_New are for new links, total 8 active
+    FIFO_B1_New = 0xE4,
     /// Various Control & Status registers (CSR3 read only)
     CSR0 = 0x00, CSR1 = 0xAA, CSR2 = 0xAC,
     CSR3 = 0xAE, CSR4 = 0xB8, CSR5 = 0xBA,

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -2015,6 +2015,42 @@ public:
   inline int  GetCFEBBadBitsNbx() { return cfeb_badbits_nbx_; }
   inline int  GetReadCFEBBadBitsNbx() { return read_cfeb_badbits_nbx_; }
   //
+  //---------------------------------------------------------------------
+  // 0X14C - 0X158 = ADR_V6_GTX_RX[CFEB]: GTX link control and monitoring
+  //---------------------------------------------------------------------
+  //Enable this GTX optical input,  disables copper input
+  inline void SetGtxRxEnable(int cfebNum, int gtx_rx_enable) { gtx_rx_enable_[cfebNum] = gtx_rx_enable; }
+  inline int  GetGtxRxEnable(int cfebNum) { return gtx_rx_enable_[cfebNum]; }
+  inline int  GetReadGtxRxEnable(int cfebNum) { return read_gtx_rx_enable_[cfebNum]; }
+  
+  //Reset this GTX
+  inline void SetGtxRxReset(int cfebNum, int gtx_rx_reset) { gtx_rx_reset_[cfebNum] = gtx_rx_reset; }
+  inline int  GetGtxRxReset(int cfebNum) { return gtx_rx_reset_[cfebNum]; }
+  inline int  GetReadGtxRxReset(int cfebNum) { return read_gtx_rx_reset_[cfebNum]; }
+  
+  //Select this GTX for PRBS test input mode
+  inline void SetGtxRxPrbsTestEnable(int cfebNum, int gtx_rx_prbs_test_enable) { gtx_rx_prbs_test_enable_[cfebNum] = gtx_rx_prbs_test_enable; }
+  inline int  GetGtxRxPrbsTestEnable(int cfebNum) { return gtx_rx_prbs_test_enable_[cfebNum]; }
+  inline int  GetReadGtxRxPrbsTestEnable(int cfebNum) { return read_gtx_rx_prbs_test_enable_[cfebNum]; }
+  
+  //GTX ready
+  inline int  GetReadGtxRxReady(int cfebNum) { return read_gtx_rx_ready_[cfebNum]; }
+  
+  //GTX link is locked (over 15 BX with clean data frames)
+  inline int  GetReadGtxRxLinkGood(int cfebNum) { return read_gtx_rx_link_good_[cfebNum]; }
+  
+  //GTX link had an error (bad data frame) since last reset
+  inline int  GetReadGtxRxLinkHadError(int cfebNum) { return read_gtx_rx_link_had_error_[cfebNum]; }
+  
+  //GTX link had over 100 errors since last reset
+  inline int  GetReadGtxRxLinkBad(int cfebNum) { return read_gtx_rx_link_bad_[cfebNum]; }
+  
+  //GTX 5,6 [ie dcfeb 4,5] have swapped rx board routes
+  inline int  GetReadGtxRxPolSwap(int cfebNum) { return read_gtx_rx_pol_swap_[cfebNum]; }
+  
+  //GTX link error count (full scale count is hex E0)
+  inline int  GetReadGtxRxErrorCount(int cfebNum) { return read_gtx_rx_error_count_[cfebNum]; }
+  
   //
   //------------------------------------------------------------------
   //0X126,128,12A = ADR_BADBITS001,BADBITS023,BADBITS045 = CFEB0 BadBits Masks
@@ -3282,6 +3318,22 @@ private:
   //
   int read_cfeb_badbits_nbx_;
   //
+  //---------------------------------------------------------------------
+  // 0X14C - 0X158 = ADR_V6_GTX_RX[CFEB]: GTX link control and monitoring
+  //---------------------------------------------------------------------
+  int gtx_rx_enable_[7];
+  int gtx_rx_reset_[7];
+  int gtx_rx_prbs_test_enable_[7];
+  
+  int read_gtx_rx_enable_[7];
+  int read_gtx_rx_reset_[7];
+  int read_gtx_rx_prbs_test_enable_[7];
+  int read_gtx_rx_ready_[7];
+  int read_gtx_rx_link_good_[7];
+  int read_gtx_rx_link_had_error_[7];
+  int read_gtx_rx_link_bad_[7];
+  int read_gtx_rx_pol_swap_[7];
+  int read_gtx_rx_error_count_[7];
   //
   //------------------------------------------------------------------
   //0X126,128,12A = ADR_BADBITS001,BADBITS023,BADBITS045 = CFEB0 BadBits Masks

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
@@ -313,6 +313,15 @@ static const unsigned long int	badbits445_adr	        = 0x000142;
 
 static const unsigned long int	v6_sysmon_adr	        = 0x00015A;  //ADR_V6_SYSMON
 
+//GTX link control and monitoring
+static const unsigned long int  v6_gtx_rx0_adr          = 0x00014C;  //ADR_V6_GTX_RX0
+static const unsigned long int  v6_gtx_rx1_adr          = 0x00014E;  //ADR_V6_GTX_RX1
+static const unsigned long int  v6_gtx_rx2_adr          = 0x000150;  //ADR_V6_GTX_RX2
+static const unsigned long int  v6_gtx_rx3_adr          = 0x000152;  //ADR_V6_GTX_RX3
+static const unsigned long int  v6_gtx_rx4_adr          = 0x000154;  //ADR_V6_GTX_RX4
+static const unsigned long int  v6_gtx_rx5_adr          = 0x000156;  //ADR_V6_GTX_RX5
+static const unsigned long int  v6_gtx_rx6_adr          = 0x000158;  //ADR_V6_GTX_RX6
+
 // extra DCFEB Bad Bits on OTMB 
 static const unsigned long int  dcfeb_badbits_ctrl_adr  = 0x00015C;  //DCFEB Bad Bit Control/Status extends Adr 122
 static const unsigned long int  badbits501_adr          = 0x00015E;  //ADR_V6_CFEB5_BADBITS_LY01
@@ -2490,6 +2499,105 @@ const int cfeb_badbits_nbx_bitlo    =  0;
 const int cfeb_badbits_nbx_bithi    =  15;
 const int cfeb_badbits_nbx_default  =  3564;
 //
+//---------------------------------------------------------------------
+// 0X14C - 0X158 = ADR_V6_GTX_RX: GTX link control and monitoring
+//---------------------------------------------------------------------
+const int gtx_rx0_enable_vmereg         =  v6_gtx_rx0_adr;
+const int gtx_rx1_enable_vmereg         =  v6_gtx_rx1_adr;
+const int gtx_rx2_enable_vmereg         =  v6_gtx_rx2_adr;
+const int gtx_rx3_enable_vmereg         =  v6_gtx_rx3_adr;
+const int gtx_rx4_enable_vmereg         =  v6_gtx_rx4_adr;
+const int gtx_rx5_enable_vmereg         =  v6_gtx_rx5_adr;
+const int gtx_rx6_enable_vmereg         =  v6_gtx_rx6_adr;
+const int gtx_rx_enable_bitlo           =  0;
+const int gtx_rx_enable_bithi           =  0;
+const int gtx_rx_enable_default         =  1;
+
+const int gtx_rx0_reset_vmereg          =  v6_gtx_rx0_adr;
+const int gtx_rx1_reset_vmereg          =  v6_gtx_rx1_adr;
+const int gtx_rx2_reset_vmereg          =  v6_gtx_rx2_adr;
+const int gtx_rx3_reset_vmereg          =  v6_gtx_rx3_adr;
+const int gtx_rx4_reset_vmereg          =  v6_gtx_rx4_adr;
+const int gtx_rx5_reset_vmereg          =  v6_gtx_rx5_adr;
+const int gtx_rx6_reset_vmereg          =  v6_gtx_rx6_adr;
+const int gtx_rx_reset_bitlo            =  1;
+const int gtx_rx_reset_bithi            =  1;
+const int gtx_rx_reset_default          =  0;
+
+const int gtx_rx0_prbs_test_enable_vmereg       =  v6_gtx_rx0_adr;
+const int gtx_rx1_prbs_test_enable_vmereg       =  v6_gtx_rx1_adr;
+const int gtx_rx2_prbs_test_enable_vmereg       =  v6_gtx_rx2_adr;
+const int gtx_rx3_prbs_test_enable_vmereg       =  v6_gtx_rx3_adr;
+const int gtx_rx4_prbs_test_enable_vmereg       =  v6_gtx_rx4_adr;
+const int gtx_rx5_prbs_test_enable_vmereg       =  v6_gtx_rx5_adr;
+const int gtx_rx6_prbs_test_enable_vmereg       =  v6_gtx_rx6_adr;
+const int gtx_rx_prbs_test_enable_bitlo        =  2;
+const int gtx_rx_prbs_test_enable_bithi        =  2;
+const int gtx_rx_prbs_test_enable_default      =  0;
+
+const int gtx_rx0_ready_vmereg          =  v6_gtx_rx0_adr;
+const int gtx_rx1_ready_vmereg          =  v6_gtx_rx1_adr;
+const int gtx_rx2_ready_vmereg          =  v6_gtx_rx2_adr;
+const int gtx_rx3_ready_vmereg          =  v6_gtx_rx3_adr;
+const int gtx_rx4_ready_vmereg          =  v6_gtx_rx4_adr;
+const int gtx_rx5_ready_vmereg          =  v6_gtx_rx5_adr;
+const int gtx_rx6_ready_vmereg          =  v6_gtx_rx6_adr;
+const int gtx_rx_ready_bitlo           =  3;
+const int gtx_rx_ready_bithi           =  3;
+
+//GTX link is locked (over 15 BX with clean data frames)
+const int gtx_rx0_link_good_vmereg      =  v6_gtx_rx0_adr;
+const int gtx_rx1_link_good_vmereg      =  v6_gtx_rx1_adr;
+const int gtx_rx2_link_good_vmereg      =  v6_gtx_rx2_adr;
+const int gtx_rx3_link_good_vmereg      =  v6_gtx_rx3_adr;
+const int gtx_rx4_link_good_vmereg      =  v6_gtx_rx4_adr;
+const int gtx_rx5_link_good_vmereg      =  v6_gtx_rx5_adr;
+const int gtx_rx6_link_good_vmereg      =  v6_gtx_rx6_adr;
+const int gtx_rx_link_good_bitlo       =  4;
+const int gtx_rx_link_good_bithi       =  4;
+
+//GTX link had an error (bad data frame) since last reset
+const int gtx_rx0_link_had_error_vmereg =  v6_gtx_rx0_adr;
+const int gtx_rx1_link_had_error_vmereg =  v6_gtx_rx1_adr;
+const int gtx_rx2_link_had_error_vmereg =  v6_gtx_rx2_adr;
+const int gtx_rx3_link_had_error_vmereg =  v6_gtx_rx3_adr;
+const int gtx_rx4_link_had_error_vmereg =  v6_gtx_rx4_adr;
+const int gtx_rx5_link_had_error_vmereg =  v6_gtx_rx5_adr;
+const int gtx_rx6_link_had_error_vmereg =  v6_gtx_rx6_adr;
+const int gtx_rx_link_had_error_bitlo  =  5;
+const int gtx_rx_link_had_error_bithi  =  5;
+
+//GTX link had over 100 errors since last reset
+const int gtx_rx0_link_bad_vmereg       =  v6_gtx_rx0_adr;
+const int gtx_rx1_link_bad_vmereg       =  v6_gtx_rx1_adr;
+const int gtx_rx2_link_bad_vmereg       =  v6_gtx_rx2_adr;
+const int gtx_rx3_link_bad_vmereg       =  v6_gtx_rx3_adr;
+const int gtx_rx4_link_bad_vmereg       =  v6_gtx_rx4_adr;
+const int gtx_rx5_link_bad_vmereg       =  v6_gtx_rx5_adr;
+const int gtx_rx6_link_bad_vmereg       =  v6_gtx_rx6_adr;
+const int gtx_rx_link_bad_bitlo        =  6;
+const int gtx_rx_link_bad_bithi        =  6;
+
+const int gtx_rx0_pol_swap_vmereg       =  v6_gtx_rx0_adr;
+const int gtx_rx1_pol_swap_vmereg       =  v6_gtx_rx1_adr;
+const int gtx_rx2_pol_swap_vmereg       =  v6_gtx_rx2_adr;
+const int gtx_rx3_pol_swap_vmereg       =  v6_gtx_rx3_adr;
+const int gtx_rx4_pol_swap_vmereg       =  v6_gtx_rx4_adr;
+const int gtx_rx5_pol_swap_vmereg       =  v6_gtx_rx5_adr;
+const int gtx_rx6_pol_swap_vmereg       =  v6_gtx_rx6_adr;
+const int gtx_rx_pol_swap_bitlo        =  7;
+const int gtx_rx_pol_swap_bithi        =  7;
+
+const int gtx_rx0_error_count_vmereg    =  v6_gtx_rx0_adr;
+const int gtx_rx1_error_count_vmereg    =  v6_gtx_rx1_adr;
+const int gtx_rx2_error_count_vmereg    =  v6_gtx_rx2_adr;
+const int gtx_rx3_error_count_vmereg    =  v6_gtx_rx3_adr;
+const int gtx_rx4_error_count_vmereg    =  v6_gtx_rx4_adr;
+const int gtx_rx5_error_count_vmereg    =  v6_gtx_rx5_adr;
+const int gtx_rx6_error_count_vmereg    =  v6_gtx_rx6_adr;
+const int gtx_rx_error_count_bitlo     =  8;
+const int gtx_rx_error_count_bithi     =  15;
+
 //
 //////////////////////////////////////////////
 // Bit mapping for TMB Raw Hits

--- a/emuDCS/PeripheralCore/src/common/CCB.cc
+++ b/emuDCS/PeripheralCore/src/common/CCB.cc
@@ -564,7 +564,6 @@ void CCB::DumpAddress(int address) {
 
 int CCB::ReadTTCrxReg(int registerAdd)
 {
-  if(ReadTTCrxID_==-1) ReadTTCrxID_=TTCrxID_;
   int pointerRegAddress = (ReadTTCrxID_*2);
   int DataRegAddress = (ReadTTCrxID_*2+1);
   int i;
@@ -638,7 +637,6 @@ int CCB::ReadTTCrxReg(int registerAdd)
 
 void CCB::WriteTTCrxReg(int registerAdd,int value)
 {
-  if(ReadTTCrxID_==-1) ReadTTCrxID_=TTCrxID_;
   int pointerRegAddress = (ReadTTCrxID_*2);
   int DataRegAddress = (ReadTTCrxID_*2+1);
   int i;

--- a/emuDCS/PeripheralCore/src/common/CCB.cc
+++ b/emuDCS/PeripheralCore/src/common/CCB.cc
@@ -1574,7 +1574,7 @@ void CCB::signal_csrb2(int cmd){
     setCCBMode(CCB::VMEFPGA);
     switchedMode=true;
   }
-  int i_ccb=cmd & 0x2F;
+  int i_ccb=cmd & 0x3F;
   sndbuf[0]=0x00;
   sndbuf[1]=(i_ccb<<2)&0xFC;
   

--- a/emuDCS/PeripheralCore/src/common/DAQMB.cc
+++ b/emuDCS/PeripheralCore/src/common/DAQMB.cc
@@ -9657,7 +9657,7 @@ void DAQMB::set_dcfeb_parambuffer(CFEB &cfeb, unsigned short int bufload[34]){
     bufload[33]=shft_bits[2];
 }
 
-void DAQMB::autoload_select_readback_wrd(CFEB &cfeb, int ival){
+unsigned DAQMB::autoload_select_readback_wrd(CFEB &cfeb, int ival){
   /*
       0 - xtra l1a w 2 bits
       1 - pre block end 4 bits
@@ -9680,8 +9680,42 @@ void DAQMB::autoload_select_readback_wrd(CFEB &cfeb, int ival){
   */
     unsigned tmp;
     dcfeb_hub(cfeb, REG_SEL_WRD, 8, &ival, (char *)&tmp, NOW);
-    return;
+    return tmp;
 }
+
+void  DAQMB::Set_TMB_TX_MODE(CFEB &cfeb,int mode) {
+  // set optical tmb path output mode
+  /*
+    mode    function
+    0       comparator mode
+
+    1       fixed patterns  continuous
+    2       counters  countinuous
+    3       prbs continuous
+    5       send 1/2 strip patterns to layers
+
+  */
+  //this->number_ = cfeb.number();
+  DEVTYPE dv   = dscamDevice(cfeb.number());
+  int mmode=mode;  //for comparator mode
+  cmd[0]=(VTX6_USR1&0xff);
+  cmd[1]=((VTX6_USR1&0x300)>>8);
+  sndbuf[0]=TMB_TX_MODE;
+  devdo(dv,10,cmd,8,sndbuf,rcvbuf,0);
+  for(int i=0;i<2;i++)rcvbuf[i]=0x55;
+  cmd[0]=(VTX6_USR2&0xff);
+  cmd[1]=((VTX6_USR2&0x300)>>8);
+  sndbuf[0]=(mode&0x7);
+  sndbuf[1]=0x00;
+  printf(" sndbuf[0] %d \n",sndbuf[0]);fflush(stdout);
+  devdo(dv,10,cmd,3,sndbuf,rcvbuf,2);
+  // printf(" rcvbuf[0] %02x \n",rcvbuf[0]&0xff);fflush(stdout);
+  cmd[0]=(VTX6_BYPASS&0xff);
+  cmd[1]=((VTX6_BYPASS&0x300)>>8);
+  sndbuf[0]=0;
+  devdo(dv,10,cmd,0,sndbuf,rcvbuf,2);
+}
+
 
 void DAQMB::autoload_readback_wrd(CFEB &cfeb, char wrd[2])
 {

--- a/emuDCS/PeripheralCore/src/common/VMEController.cc
+++ b/emuDCS/PeripheralCore/src/common/VMEController.cc
@@ -1226,7 +1226,7 @@ void VMEController::set_Timeout(int to)
   // "to" is in microsecond
   if(to<0) return;
   unsigned n=(to*1000)>>4;
-  unsigned short tvalue=((n>>8)&0xff) +((n&0xff)<<8);
+  unsigned short tvalue=(n>>8)&0xff +((n&0xff)<<8);
   vcc_write_command(0x13, 1, &tvalue);
   std::cout << "VME Bus Timeout set to " << to << " microseconds" <<std::endl;
   return;
@@ -1237,7 +1237,7 @@ void VMEController::set_GrantTimeout(int to)
   // "to" is in microsecond
   if(to<0) return;
   unsigned n=(to*1000)>>4;
-  unsigned short tvalue=((n>>8)&0xff) +((n&0xff)<<8);
+  unsigned short tvalue=(n>>8)&0xff +((n&0xff)<<8);
   vcc_write_command(0x14, 1, &tvalue);
   std::cout << "VME BusGrant Timeout set to " << to << " microseconds" <<std::endl;
   return;
@@ -1248,38 +1248,17 @@ void VMEController::get_macaddr(int realport)
   int msock_fd;
   struct ifreq mifr;
 
-   char eth[5]="eth2"; // the old ethX device
-   eth[3] = '0' + realport;
+  char eth[5]="eth2";
 
-   char pci[5]="p1p1"; // the new pXpY device
-   // I350 card in SLC6: 
-   //     port 2 ---- p1p1
-   //          3 ---- p1p2
-   //     port 4 ---- p2p1
-   //          5 ---- p2p2
-   if(realport<4)
-   {
-      pci[3] = '0' + realport - 1; 
-   }
-   else
-   {
-      pci[1]= '2';
-      pci[3] = '0' + realport - 3; 
-   }
-
+   eth[3] = '0' + realport; 
    //create socket
    if((msock_fd = socket(PF_INET, SOCK_STREAM, 0)) == -1)
      std::cout << "Error in call: socket()" << std::endl;
      
    //get MAC address
-   strcpy(mifr.ifr_name, pci);   // try the new device first
+   strcpy(mifr.ifr_name, eth);
    if(ioctl(msock_fd,SIOCGIFHWADDR,&mifr) < 0)
-   {
-      // if the new device doesn't work, try the old one
-      strcpy(mifr.ifr_name, eth);
-      if(ioctl(msock_fd,SIOCGIFHWADDR,&mifr) < 0)
-         std::cout << "Error in call ioctl(socket, SIOCGIFHWADDR)" << std::endl;
-   }
+     std::cout << "Error in call ioctl(socket, SIOCGIFHWADDR)" << std::endl;
    
    memcpy(hw_source_addr,mifr.ifr_addr.sa_data, ETH_ALEN);
    memcpy(ether_header.h_source, hw_source_addr, ETH_ALEN);
@@ -1672,7 +1651,7 @@ int VMEController::vme_controller(int irdwr,unsigned int ptr,unsigned short int 
 
 void VMEController::write_Ethernet_CR(unsigned short int val)
 {
-  unsigned short tvalue=((val>>8)&0xff) +((val&0xff)<<8);
+  unsigned short tvalue=(val>>8)&0xff +((val&0xff)<<8);
   vcc_write_command(0x0F, 1, &tvalue);
   std::cout << "Write_Ethernet_CR to " << std::hex << val << std::dec << std::endl;
   return;
@@ -1680,7 +1659,7 @@ void VMEController::write_Ethernet_CR(unsigned short int val)
 
 void VMEController::write_FIFO_CR(unsigned short int val)
 {
-  unsigned short tvalue=((val>>8)&0xff) +((val&0xff)<<8);
+  unsigned short tvalue=(val>>8)&0xff +((val&0xff)<<8);
   vcc_write_command(0x10, 1, &tvalue);
   std::cout << "Write_FIFO_CR to " << std::hex << val << std::dec << std::endl;
   return;
@@ -1688,7 +1667,7 @@ void VMEController::write_FIFO_CR(unsigned short int val)
 
 void VMEController::write_ResetMisc_CR(unsigned short int val)
 {
-  unsigned short tvalue=((val>>8)&0xff) +((val&0xff)<<8);
+  unsigned short tvalue=(val>>8)&0xff +((val&0xff)<<8);
   vcc_write_command(0x11, 1, &tvalue);
   std::cout << "Write_ResetMisc_CR to " << std::hex << val << std::dec << std::endl;
   return;
@@ -1697,8 +1676,8 @@ void VMEController::write_ResetMisc_CR(unsigned short int val)
 void VMEController::write_VME_CR(unsigned int val)
 {
   unsigned short tvalue[2];
-  tvalue[1]=((val>>8)&0xff) +((val&0xff)<<8); 
-  tvalue[0]=((val>>24)&0xff) +(((val>>16)&0xff)<<8); 
+  tvalue[1]=(val>>8)&0xff +((val&0xff)<<8); 
+  tvalue[0]=(val>>24)&0xff +(((val>>16)&0xff)<<8); 
   vcc_write_command(0x12, 2, tvalue);
   std::cout << "Write_VME_CR to " << std::hex << val << std::dec << std::endl;
   return;
@@ -1706,7 +1685,7 @@ void VMEController::write_VME_CR(unsigned int val)
 
 void VMEController::write_BusTimeOut_CR(unsigned short int val)
 {
-  unsigned short tvalue=((val>>8)&0xff) +((val&0xff)<<8);
+  unsigned short tvalue=(val>>8)&0xff +((val&0xff)<<8);
   vcc_write_command(0x13, 1, &tvalue);
   std::cout << "Write_BusTimeOut_CR to " << std::hex << val << std::dec << std::endl;
   return;
@@ -1715,7 +1694,7 @@ void VMEController::write_BusTimeOut_CR(unsigned short int val)
 void VMEController::write_BusGrantTimeOut_CR(unsigned short int val)
 {
 
-  unsigned short tvalue=((val>>8)&0xff) +((val&0xff)<<8);
+  unsigned short tvalue=(val>>8)&0xff +((val&0xff)<<8);
   vcc_write_command(0x14, 1, &tvalue);
   std::cout << "Write_BusGrantTimeOut_CR to " << std::hex << val << std::dec << std::endl;
   return;


### PR DESCRIPTION
```
Ok, so I added the new register addresses and the various bit location pointers and their default 
values to the TMB_constants.h, then also updated TMB.h and TMB.cc file to add the new variables 
holding all of the new statuses values and readback values and also methods to set, get and read 
them. I also added the RW bits of the new registers to the TMB configuration registers in 
DefineTMBConfigurationRegisters_() and their default values to be written to flash in 
SetTMBRegisterDefaults(), then also updated DecodeTMBRegister_() to decode the register
 values and fill the readback variables and also in PrintTMBRegister() I added some human
 readable printout of the new registers. e.g. looks like this:

->GTX optical input control and monitoring:
    Input enable [DCFEBs 0-6]:      [ 1 1 1 1 1 1 1 ]
    Input reset [DCFEBs 0-6]:       [ 0 0 0 0 0 0 0 ]
    PRBS test enable [DCFEBs 0-6]:  [ 0 0 0 0 0 0 0 ]
    Input ready [DCFEBs 0-6]:       [ 1 1 1 1 1 1 1 ]
    Link good [DCFEBs 0-6]:         [ 1 1 1 1 1 1 1 ]
    Link had errors [DCFEBs 0-6]:   [ 1 1 1 1 1 1 1 ]
    Link bad [DCFEBs 0-6]:      [ 0 0 0 0 0 0 0 ]
    Link error count [DCFEBs 0-6]:  [ 1 1 1 1 1 1 1 ]


I also updated PeripheralApps to use the PrintTMBRegisters() to print the new stuff in 
the TMB status page if harware version is 
```
