### PR TITLE
ME1/1 handling updates: TMB hardware version, CFEB RX delays for A and B side

### DIFF
--- a/emuDCS/PeripheralApps/include/emu/pc/ChamberUtilities.h
+++ b/emuDCS/PeripheralApps/include/emu/pc/ChamberUtilities.h
@@ -64,7 +64,7 @@ public:
   void CFEBTiming();                           //default is normal_scan
   void CFEBTiming(CFEBTiming_scanType);
   void CFEBTiming_with_Posnegs_simple_routine(int time_delay, int cfeb_num, unsigned int layers, unsigned int pattern, 
-					      int halfstrip, bool print_data, int cfeb_clock_phase);
+					      int halfstrip, bool print_data, int cfeb_clock_phase, bool groupME11AandB);
   void CFEBTiming_with_Posnegs(CFEBTiming_scanType);
   void CFEBTiming_without_Posnegs();
   //

--- a/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
+++ b/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
@@ -690,6 +690,10 @@ void ChamberUtilities::SetCfebRxPosNeg(int posneg) {
   thisTMB->SetCfeb4RxPosNeg(posneg);
   thisTMB->SetCfeb5RxPosNeg(posneg);
   thisTMB->SetCfeb6RxPosNeg(posneg);
+  if (thisTMB->GetHardwareVersion()>=2){
+    thisTMB->SetCfeb0123RxPosNeg(posneg);
+    thisTMB->SetCfeb456RxPosNeg(posneg);
+  }
   //usleep(10000);
 }
 
@@ -1171,7 +1175,7 @@ inline void ChamberUtilities::CFEBTiming_ConfigureLevel(CFEBTiming_Configuration
     //
 void ChamberUtilities::CFEBTiming_PulseInject(bool is_inject_scan, int cfeb, unsigned int layer_mask, unsigned int pattern, 
 					      unsigned int halfstrip, unsigned int n_pulses, unsigned int pulse_delay) {
-  std::cout << "Start: " << __PRETTY_FUNCTION__  << std::endl;
+  if (debug_ >= 5) std::cout << "Start: " << __PRETTY_FUNCTION__  << std::endl;
   const int MaxCFEB = 5;
   const int MaxTimeDelay=25;
   const bool is_cfeb_scan = cfeb < 0;
@@ -1225,7 +1229,7 @@ void ChamberUtilities::CFEBTiming_PulseInject(bool is_inject_scan, int cfeb, uns
       //thisCCB_->inject(1,0x4f);
     }
   }
-  std::cout << "End: " << __PRETTY_FUNCTION__  << std::endl;
+  if (debug_ >= 5) std::cout << "End: " << __PRETTY_FUNCTION__  << std::endl;
 }
     
 void ChamberUtilities::SetTMBL1ADelay(int delay) {
@@ -1514,7 +1518,8 @@ void ChamberUtilities::Print_CFEB_Masks() {
 }
     //
 void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, int cfeb_num, unsigned int layers, unsigned int pattern, 
-							      int halfstrip, bool print_data, int cfeb_clock_phase) {
+							      int halfstrip, bool print_data, int cfeb_clock_phase,
+							      bool groupME11AandB) {
   
   std::time_t init_time=time(0);
   
@@ -1526,8 +1531,10 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
     std::fstream bad_packets_file((CFEBTiming_log_dir_ + "SimpleScan_BadPackets.txt").c_str(), std::ios_base::out);*/
   std::ostream * web_out = MyOutput_;
   std::ofstream web_backup;
+  std::string env_user    = std::getenv("USER");
+  std::string out1_file_name = CFEBTiming_log_dir_+"webout_"+env_user+"_backup1.txt";
   if(print_data) web_backup.open((CFEBTiming_log_dir_+"webout_backup_fullcrate.txt").c_str(), std::ios::app);
-  else web_backup.open((CFEBTiming_log_dir_+"webout_backup1.txt").c_str(), std::ios::out);
+  else web_backup.open(out1_file_name.c_str(), std::ios::out);
   
   print_data=false;
   
@@ -1570,7 +1577,7 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
   if(time_delay >= MaxTimeDelay) return;
   if(cfeb_num >= MaxCFEB) return;
   if(halfstrip >= MaxHalfStrip) return;
-  if(cfeb_clock_phase > MaxCFEBClockPhase) return;
+  if(cfeb_clock_phase > MaxCFEBClockPhase) return; // cfeb_clock_phase==MaxCFEBClockPhase is legal
   
   thisTMB->ReadRegister(non_trig_readout_adr);
   int tmb_compile_type = thisTMB->GetReadTMBFirmwareCompileType();
@@ -1647,29 +1654,51 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
       web_backup << "DCFEB " << cfeb << " clock phase = " << config.cfeb_clock_phase << std::endl;
     }
 
-    thisTMB->ReadRegister(phaser_cfeb0_rxd_adr); // Get phaser information
-    thisTMB->ReadRegister(phaser_cfeb1_rxd_adr);
-    thisTMB->ReadRegister(phaser_cfeb2_rxd_adr);
-    thisTMB->ReadRegister(phaser_cfeb3_rxd_adr);
-    thisTMB->ReadRegister(phaser_cfeb4_rxd_adr);
-    thisTMB->ReadRegister(phaser_cfeb456_rxd_adr);
-    thisTMB->ReadRegister(phaser_cfeb0123_rxd_adr);
+    if (!groupME11AandB){
+      thisTMB->ReadRegister(phaser_cfeb0_rxd_adr); // Get phaser information
+      thisTMB->ReadRegister(phaser_cfeb1_rxd_adr);
+      thisTMB->ReadRegister(phaser_cfeb2_rxd_adr);
+      thisTMB->ReadRegister(phaser_cfeb3_rxd_adr);
+      thisTMB->ReadRegister(phaser_cfeb4_rxd_adr);
+      thisTMB->ReadRegister(phaser_cfeb456_rxd_adr);
+      thisTMB->ReadRegister(phaser_cfeb0123_rxd_adr);
+    } else {
+      thisTMB->ReadRegister(phaser_cfeb456_rxd_adr);
+      thisTMB->ReadRegister(phaser_cfeb0123_rxd_adr);
+    }
     //
-    initial_cfeb_phase[0] = thisTMB->GetReadCfeb0RxClockDelay();
-    initial_cfeb_phase[1] = thisTMB->GetReadCfeb1RxClockDelay();
-    initial_cfeb_phase[2] = thisTMB->GetReadCfeb2RxClockDelay();
-    initial_cfeb_phase[3] = thisTMB->GetReadCfeb3RxClockDelay();
-    initial_cfeb_phase[4] = thisTMB->GetReadCfeb4RxClockDelay();
-    initial_cfeb_phase[5] = thisTMB->GetReadCfeb456RxClockDelay();
-    initial_cfeb_phase[6] = thisTMB->GetReadCfeb0123RxClockDelay();
-    //
-    initial_cfeb_posneg[0] = thisTMB->GetReadCfeb0RxPosNeg();
-    initial_cfeb_posneg[1] = thisTMB->GetReadCfeb1RxPosNeg();
-    initial_cfeb_posneg[2] = thisTMB->GetReadCfeb2RxPosNeg();
-    initial_cfeb_posneg[3] = thisTMB->GetReadCfeb3RxPosNeg();
-    initial_cfeb_posneg[4] = thisTMB->GetReadCfeb4RxPosNeg();
-    initial_cfeb_posneg[5] = thisTMB->GetReadCfeb456RxPosNeg();
-    initial_cfeb_posneg[6] = thisTMB->GetReadCfeb0123RxPosNeg();
+    if (!groupME11AandB){
+      initial_cfeb_phase[0] = thisTMB->GetReadCfeb0RxClockDelay();
+      initial_cfeb_phase[1] = thisTMB->GetReadCfeb1RxClockDelay();
+      initial_cfeb_phase[2] = thisTMB->GetReadCfeb2RxClockDelay();
+      initial_cfeb_phase[3] = thisTMB->GetReadCfeb3RxClockDelay();
+      initial_cfeb_phase[4] = thisTMB->GetReadCfeb4RxClockDelay();
+      initial_cfeb_phase[5] = thisTMB->GetReadCfeb456RxClockDelay();
+      initial_cfeb_phase[6] = thisTMB->GetReadCfeb0123RxClockDelay();
+      //
+      initial_cfeb_posneg[0] = thisTMB->GetReadCfeb0RxPosNeg();
+      initial_cfeb_posneg[1] = thisTMB->GetReadCfeb1RxPosNeg();
+      initial_cfeb_posneg[2] = thisTMB->GetReadCfeb2RxPosNeg();
+      initial_cfeb_posneg[3] = thisTMB->GetReadCfeb3RxPosNeg();
+      initial_cfeb_posneg[4] = thisTMB->GetReadCfeb4RxPosNeg();
+      initial_cfeb_posneg[5] = thisTMB->GetReadCfeb456RxPosNeg();
+      initial_cfeb_posneg[6] = thisTMB->GetReadCfeb0123RxPosNeg();
+    } else {
+      int initialPhase0123 = thisTMB->GetReadCfeb0123RxClockDelay();
+      int initialPhase456 = thisTMB->GetReadCfeb456RxClockDelay();
+
+      int initialPosneg0123 = thisTMB->GetReadCfeb0123RxPosNeg();
+      int initialPosneg456 = thisTMB->GetReadCfeb456RxPosNeg();
+
+      for (int i=0;i<4;++i){
+	initial_cfeb_phase[i] = initialPhase0123;
+	initial_cfeb_posneg[i] = initialPosneg0123;
+      }
+      for (int i=4;i<7;++i){
+	initial_cfeb_phase[i] = initialPhase456;
+	initial_cfeb_posneg[i] = initialPosneg456;
+      }
+    }
     //
     initial_cfeb_rxd_int_delay[0] = thisTMB->GetCFEB0RxdIntDelay();
     initial_cfeb_rxd_int_delay[1] = thisTMB->GetCFEB1RxdIntDelay();
@@ -1681,7 +1710,7 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
     //
     
   }
-  else {
+  else { //not is_me11_
     thisCCB_->setCCBMode(CCB::VMEFPGA);
     thisCCB_->hardReset();
     thisCCB_->setCCBMode(CCB::DLOG);
@@ -1801,11 +1830,13 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
 	if(print_data)
 	  CFEBTiming_ConfigureLevel(config, 3, true);
 	else	SetCfebRxClockDelay(TimeDelay);
+	std::cout<<"Scanning ... now in TimeDelay "<<TimeDelay<<" posneg "<<posneg<<std::endl;
+	  
 	// Loop over CFEBs or choose a single CFEB
 	for(int cfeb = (is_cfeb_scan)?(0):(cfeb_num); ((is_cfeb_scan)?(cfeb<MaxCFEB):(cfeb==cfeb_num)) && (!done); ++cfeb) {
 	  usleep(50);
 	  int last_halfstrip = -1;
-	  
+
 	  for(int ihs = 0; ((is_random_halfstrip)?(ihs<ihs_max):(ihs<1)) && (!done); ++ihs) { 
 	    if(print_data) {
 	      Clear_ODMB_FIFO();
@@ -1871,7 +1902,7 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
 	      }
 	      
 	      if(thisTMB->GetCLCT0keyHalfStrip() == last_hs[cfeb]) {
-		std::cout << "Got last halfstrip!" << std::endl;
+		if (debug_ >= 5) std::cout << "Got last halfstrip!" << std::endl;
 	      }
 	      
 	      last_hs[cfeb] = thisTMB->GetCLCT0keyHalfStrip();
@@ -1884,7 +1915,10 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
 		++pulse_count_hs_integral[posneg][TimeDelay];
 		++pulse_count_cfeb[cfeb];
 		++pulse_count_cfeb_rx[cfeb][posneg][TimeDelay];
-	        ++timing_2d_results[posneg][cfeb_phase][TimeDelay];
+	        if (cfeb_phase >= 0 && cfeb_phase < MaxCFEBClockPhase){
+		  //fill only when we are really scanning: 32 and -1 inputs are possible for special cases
+		  ++timing_2d_results[posneg][cfeb_phase][TimeDelay];
+		}
 	      }
 	      
 	      if(!good_valid)
@@ -2333,7 +2367,7 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
     }
   }
   //
-  else {
+  else {//not is_me11_
     thisTMB->SetCfeb0RxClockDelay(initial_cfeb_phase[0]);
     thisTMB->SetCfeb0RxPosNeg(initial_cfeb_posneg[0]);
     thisTMB->WriteRegister(phaser_cfeb0_rxd_adr);
@@ -7752,7 +7786,7 @@ void ChamberUtilities::PulseHalfstrips(int * hs_normal, bool enableL1aEmulator) 
   }
   //
   // Shift the pulsing information to the CFEBs
-  thisDMB->chan2shift(chan);
+  thisDMB->chan2shift(chan); //use chan2shift(chan, true) to enable debug
   //
   thisTMB->EnableCLCTInputs(CLCTInputs);
   //

--- a/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
+++ b/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
@@ -715,13 +715,13 @@ void ChamberUtilities::SetCfebRxClockDelay(int delay) {
   thisTMB->FirePhaser(phaser_cfeb4_rxd_adr);
   //
   if(thisTMB->GetHardwareVersion() == 2) {
-    thisTMB->SetCfeb5RxClockDelay(delay);
-    thisTMB->WriteRegister(phaser_cfeb5_rxd_adr);
-    thisTMB->FirePhaser(phaser_cfeb5_rxd_adr);
+    thisTMB->SetCfeb456RxClockDelay(delay);
+    thisTMB->WriteRegister(phaser_cfeb456_rxd_adr);
+    thisTMB->FirePhaser(phaser_cfeb456_rxd_adr);
     //
-    thisTMB->SetCfeb6RxClockDelay(delay);
-    thisTMB->WriteRegister(phaser_cfeb6_rxd_adr);
-    thisTMB->FirePhaser(phaser_cfeb6_rxd_adr);
+    thisTMB->SetCfeb0123RxClockDelay(delay);
+    thisTMB->WriteRegister(phaser_cfeb0123_rxd_adr);
+    thisTMB->FirePhaser(phaser_cfeb0123_rxd_adr);
   }
   //usleep(10000);
 }
@@ -1652,24 +1652,24 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
     thisTMB->ReadRegister(phaser_cfeb2_rxd_adr);
     thisTMB->ReadRegister(phaser_cfeb3_rxd_adr);
     thisTMB->ReadRegister(phaser_cfeb4_rxd_adr);
-    thisTMB->ReadRegister(phaser_cfeb5_rxd_adr);
-    thisTMB->ReadRegister(phaser_cfeb6_rxd_adr);
+    thisTMB->ReadRegister(phaser_cfeb456_rxd_adr);
+    thisTMB->ReadRegister(phaser_cfeb0123_rxd_adr);
     //
     initial_cfeb_phase[0] = thisTMB->GetReadCfeb0RxClockDelay();
     initial_cfeb_phase[1] = thisTMB->GetReadCfeb1RxClockDelay();
     initial_cfeb_phase[2] = thisTMB->GetReadCfeb2RxClockDelay();
     initial_cfeb_phase[3] = thisTMB->GetReadCfeb3RxClockDelay();
     initial_cfeb_phase[4] = thisTMB->GetReadCfeb4RxClockDelay();
-    initial_cfeb_phase[5] = thisTMB->GetReadCfeb5RxClockDelay();
-    initial_cfeb_phase[6] = thisTMB->GetReadCfeb6RxClockDelay();
+    initial_cfeb_phase[5] = thisTMB->GetReadCfeb456RxClockDelay();
+    initial_cfeb_phase[6] = thisTMB->GetReadCfeb0123RxClockDelay();
     //
     initial_cfeb_posneg[0] = thisTMB->GetReadCfeb0RxPosNeg();
     initial_cfeb_posneg[1] = thisTMB->GetReadCfeb1RxPosNeg();
     initial_cfeb_posneg[2] = thisTMB->GetReadCfeb2RxPosNeg();
     initial_cfeb_posneg[3] = thisTMB->GetReadCfeb3RxPosNeg();
     initial_cfeb_posneg[4] = thisTMB->GetReadCfeb4RxPosNeg();
-    initial_cfeb_posneg[5] = thisTMB->GetReadCfeb5RxPosNeg();
-    initial_cfeb_posneg[6] = thisTMB->GetReadCfeb6RxPosNeg();
+    initial_cfeb_posneg[5] = thisTMB->GetReadCfeb456RxPosNeg();
+    initial_cfeb_posneg[6] = thisTMB->GetReadCfeb0123RxPosNeg();
     //
     initial_cfeb_rxd_int_delay[0] = thisTMB->GetCFEB0RxdIntDelay();
     initial_cfeb_rxd_int_delay[1] = thisTMB->GetCFEB1RxdIntDelay();
@@ -1884,6 +1884,7 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
 		++pulse_count_hs_integral[posneg][TimeDelay];
 		++pulse_count_cfeb[cfeb];
 		++pulse_count_cfeb_rx[cfeb][posneg][TimeDelay];
+	        ++timing_2d_results[posneg][cfeb_phase][TimeDelay];
 	      }
 	      
 	      if(!good_valid)
@@ -2306,15 +2307,15 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
     thisTMB->WriteRegister(phaser_cfeb4_rxd_adr);
     thisTMB->FirePhaser(phaser_cfeb4_rxd_adr);
     //
-    thisTMB->SetCfeb5RxClockDelay(initial_cfeb_phase[5]);
-    thisTMB->SetCfeb5RxPosNeg(initial_cfeb_posneg[5]);
-    thisTMB->WriteRegister(phaser_cfeb5_rxd_adr);
-    thisTMB->FirePhaser(phaser_cfeb5_rxd_adr);
+    thisTMB->SetCfeb456RxClockDelay(initial_cfeb_phase[5]);
+    thisTMB->SetCfeb456RxPosNeg(initial_cfeb_posneg[5]);
+    thisTMB->WriteRegister(phaser_cfeb456_rxd_adr);
+    thisTMB->FirePhaser(phaser_cfeb456_rxd_adr);
     //
-    thisTMB->SetCfeb6RxClockDelay(initial_cfeb_phase[6]);
-    thisTMB->SetCfeb6RxPosNeg(initial_cfeb_posneg[6]);
-    thisTMB->WriteRegister(phaser_cfeb6_rxd_adr);
-    thisTMB->FirePhaser(phaser_cfeb6_rxd_adr);
+    thisTMB->SetCfeb0123RxClockDelay(initial_cfeb_phase[6]);
+    thisTMB->SetCfeb0123RxPosNeg(initial_cfeb_posneg[6]);
+    thisTMB->WriteRegister(phaser_cfeb0123_rxd_adr);
+    thisTMB->FirePhaser(phaser_cfeb0123_rxd_adr);
     //
     if(!is_cfeb_clock_phase_inherited) {
       //

--- a/emuDCS/PeripheralApps/src/common/EmuEndcapConfigWrapper.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuEndcapConfigWrapper.cc
@@ -406,7 +406,9 @@ throw (emu::exception::ConfigurationException)
   {
     XCEPT_RAISE(emu::exception::ConfigurationException, std::string("Failed to get TMB slot") );
   }
-  TMB * tmb_ = new TMB(theCrate, theChamber, slot);
+  int tmbHwVersion = 0;
+  if (conf->has("HARDWARE_VERSION"))       tmbHwVersion =  getInt(conf, "HARDWARE_VERSION");
+  TMB * tmb_ = new TMB(theCrate, theChamber, slot, tmbHwVersion);
 
   if (conf->has("TMB_FIRMWARE_MONTH"))         tmb_->SetExpectedTmbFirmwareMonth( getInt(conf, "TMB_FIRMWARE_MONTH"));
   if (conf->has("TMB_FIRMWARE_DAY"))           tmb_->SetExpectedTmbFirmwareDay( getInt(conf, "TMB_FIRMWARE_DAY"));
@@ -535,7 +537,6 @@ throw (emu::exception::ConfigurationException)
   if (conf->has("CFEB_BADBITS_READOUT"))   tmb_->SetCFEBBadBitsReadout( getInt(conf, "CFEB_BADBITS_READOUT"));
   if (conf->has("L1A_PRIORITY_ENABLE"))    tmb_->SetL1APriorityEnable( getInt(conf, "L1A_PRIORITY_ENABLE"));
   if (conf->has("MINISCOPE_ENABLE"))       tmb_->SetMiniscopeEnable( getInt(conf, "MINISCOPE_ENABLE"));
-  if (conf->has("HARDWARE_VERSION"))       tmb_->SetHardwareVersion( getInt(conf, "HARDWARE_VERSION"));
 
   if(verbose_)
   {

--- a/emuDCS/PeripheralApps/src/common/EmuPCrateConfigTStore.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPCrateConfigTStore.cc
@@ -3460,7 +3460,18 @@ void EmuPCrateConfigTStore::readTMB(
         if (i) slot = (int) *i;
       }
     }
-    TMB * tmb_ = new TMB(theCrate, theChamber, slot);
+    int tmbHwVersion = 0;
+    for (std::vector<std::string>::iterator column = columns.begin(); column != columns.end(); ++column)
+      {
+	if (*column != "HARDWARE_VERSION"      ) continue;
+	value = results.getValueAt(rowIndex, *column);
+	if (results.getColumnType(*column) == "int")
+	  {
+	    xdata::Integer * i = dynamic_cast<xdata::Integer *> (value);
+	    if(! i->isNaN()) tmbHwVersion=(int)*i;
+	  }
+      }
+    TMB * tmb_ = new TMB(theCrate, theChamber, slot, tmbHwVersion);
     for (std::vector<std::string>::iterator column = columns.begin(); column != columns.end(); ++column)
     {
       value = results.getValueAt(rowIndex, *column);
@@ -3625,7 +3636,6 @@ void EmuPCrateConfigTStore::readTMB(
       if (*column == "CFEB_BADBITS_READOUT"  ) tmb_->SetCFEBBadBitsReadout(IntValue);
       if (*column == "L1A_PRIORITY_ENABLE"   ) tmb_->SetL1APriorityEnable(IntValue);
       if (*column == "MINISCOPE_ENABLE"      ) tmb_->SetMiniscopeEnable(IntValue);
-      if (*column == "HARDWARE_VERSION"      ) tmb_->SetHardwareVersion(IntValue);
       
       if (*column == "TMB_CONFIG_ID" ) tmb_config_id_ = StrgValue;
     }

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
@@ -5104,6 +5104,9 @@ void EmuPeripheralCrateConfig::ChamberTests(xgi::Input * in, xgi::Output * out )
   *out << cgicc::td().set("ALIGN", "left") << "CFEB" << cgicc::td() << std::endl;
   *out << cgicc::td().set("ALIGN", "left") << "Pattern Type" << cgicc::td() << std::endl;
   *out << cgicc::td().set("ALIGN", "left") << "Half-Strip" << cgicc::td() << std::endl;
+  if (thisTMB->GetHardwareVersion()>=2){
+    *out << cgicc::td().set("ALIGN", "left") << "Group ME11 A and B" << cgicc::td() << std::endl;
+  }
   //
   *out << cgicc::tr();
   //
@@ -5141,6 +5144,14 @@ void EmuPeripheralCrateConfig::ChamberTests(xgi::Input * in, xgi::Output * out )
   for(int i=0; i<32; ++i) *out << cgicc::option().set("value", toolbox::toString("%d", i)) << i << cgicc::option() << std::endl;
   *out << cgicc::select() << std::endl;
   *out << cgicc::td();
+  if (thisTMB->GetHardwareVersion()>=2){
+    *out << cgicc::td().set("ALIGN", "left") << std::endl;
+    *out << cgicc::select().set("name", "groupME11AandB") << std::endl;
+    *out << cgicc::option().set("value", "yes") << "yes" << cgicc::option() << std::endl;
+    *out << cgicc::option().set("value", "no") << "no" << cgicc::option() << std::endl;
+    *out << cgicc::select() << std::endl;
+    *out << cgicc::td();
+  }
   *out << cgicc::td();
   *out << cgicc::input().set("type","submit").set("value", "CFEB RX Delay Scan").set("style", "color:blue") << std::endl;
   *out << cgicc::td();
@@ -5767,7 +5778,8 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScan(xgi::Input * in, xgi::Output
   int halfstrip = 16;
   bool print_data = false;
   unsigned cfeb_phase = 0x0;
-  
+  bool groupME11AandB = false;
+
   //
   name = cgi.getElement("time_delay");
   if(name != cgi.getElements().end()) {
@@ -5793,6 +5805,11 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScan(xgi::Input * in, xgi::Output
   if(name != cgi.getElements().end()) {
     cfeb_phase = cgi["cfeb_phase"]->getIntegerValue();
   }
+  //
+  name = cgi.getElement("groupME11AandB");
+  if(name != cgi.getElements().end()) {
+    groupME11AandB = cgi["groupME11AandB"]->getValue() == "yes";
+  }
   
   std::cout << "time_delay: " << time_delay << std::endl;
   std::cout << "cfeb_num: " << cfeb_num << std::endl;
@@ -5800,9 +5817,10 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScan(xgi::Input * in, xgi::Output
   std::cout << "pattern: " << pattern << std::endl;
   std::cout << "halfstrip: " << halfstrip << std::endl;
   std::cout << "cfeb_phase: " << cfeb_phase << std::endl;
+  std::cout << "groupME11AandB: "<< groupME11AandB << std::endl;
   //
   MyTest[tmb][current_crate_].RedirectOutput(&ChamberTestsOutput[tmb][current_crate_]);
-  MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase);
+  MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase, groupME11AandB);
   MyTest[tmb][current_crate_].RedirectOutput(&std::cout);
   //
   this->ChamberTests(in,out);
@@ -5968,6 +5986,7 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_me11(xgi::Input * in, 
 	int halfstrip = -1;
 	bool print_data = true;
 	unsigned cfeb_phase = 32;
+	bool groupME11AandB = true;
 	
 	//
 	
@@ -5977,6 +5996,7 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_me11(xgi::Input * in, 
 	std::cout << "pattern: " << pattern << std::endl;
 	std::cout << "halfstrip: " << halfstrip << std::endl;
 	std::cout << "cfeb_phase: " << cfeb_phase << std::endl;
+	std::cout << "groupME11AandB: "<< groupME11AandB << std::endl;
 	//
 	//
 	if(thisCrate->GetTMB(tmbVector[tmb]->slot())->GetHardwareVersion() != 2) {
@@ -5998,7 +6018,7 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_me11(xgi::Input * in, 
 	web_backup.close();
 	//
 	MyTest[tmb][current_crate_].RedirectOutput(&ChamberTestsOutput[tmb][current_crate_]);
-	MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase);
+	MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase, groupME11AandB);
 	MyTest[tmb][current_crate_].RedirectOutput(&std::cout);
 	//
 	web_backup.open("/tmp/webout_backup_fullcrate.txt", std::ios::app);
@@ -6078,7 +6098,7 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_non_me11(xgi::Input * 
 	int halfstrip = -1;
 	bool print_data = true;
 	unsigned cfeb_phase = 32;
-	
+	bool groupME11AandB = true;
 	//
 	
 	std::cout << "time_delay: " << time_delay << std::endl;
@@ -6087,6 +6107,7 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_non_me11(xgi::Input * 
 	std::cout << "pattern: " << pattern << std::endl;
 	std::cout << "halfstrip: " << halfstrip << std::endl;
 	std::cout << "cfeb_phase: " << cfeb_phase << std::endl;
+	std::cout << "groupME11AandB: " << groupME11AandB << std::endl;
 	//
 	//
 	if(thisCrate->GetTMB(tmbVector[tmb]->slot())->GetHardwareVersion() == 2) {
@@ -6108,7 +6129,7 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_non_me11(xgi::Input * 
 	web_backup.close();
 	//
 	MyTest[tmb][current_crate_].RedirectOutput(&ChamberTestsOutput[tmb][current_crate_]);
-	MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase);
+	MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase, groupME11AandB);
 	MyTest[tmb][current_crate_].RedirectOutput(&std::cout);
 	//
 	web_backup.open("/tmp/webout_backup_fullcrate.txt", std::ios::app);

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
@@ -9649,87 +9649,90 @@ void EmuPeripheralCrateConfig::TMBUtils(xgi::Input * in, xgi::Output * out )
   *out << cgicc::input().set("type","hidden").set("value",buf).set("name","tmb");
   *out << cgicc::form() << std::endl ;
   //
-  std::string TMBFiberReset = toolbox::toString("/%s/TMBFiberReset",
-    getApplicationDescriptor()->getURN().c_str());
-  *out << cgicc::form().set("method", "GET").set("action", TMBFiberReset);
-  *out << cgicc::input().set("type", "submit").set("value", "Read GTX Fiber Status");
-  sprintf(buf, "%d", tmb);
-  *out
-    << cgicc::input().set("type", "hidden").set("value", buf).set("name",
-      "tmb");
-  *out
-    << cgicc::input().set("type", "hidden").set("value", "read").set("name",
-      "mode");
-  *out << cgicc::form() << std::endl;
-  //
-  *out << cgicc::table().set("border", "1");
-  *out << cgicc::tr();
-  *out << cgicc::td();
-  *out << "Fiber";
-  *out << cgicc::td();
-  *out << cgicc::td();
-  *out << "Status/Toggle";
-  *out << cgicc::td();
-  *out << cgicc::td();
-  *out << "Reset";
-  *out << cgicc::td();
-  *out << cgicc::tr();
-  std::string fiber_num = "all";
-  for (int i = -1; i < ((int) TMB_N_FIBERS); ++i) {
-    *out << cgicc::tr();
-    *out << cgicc::td();
-    *out << fiber_num;
-    *out << cgicc::td();
-    *out << cgicc::td();
-    //
-    if (tmb_fiber_status_read_) {
-      bool read_status = false;
-      if (i < 0) {
-        read_status = thisTMB->GetReadGtxRxAllEnable();
-      } else {
-        read_status = thisTMB->GetReadGtxRxEnable(i);
-      }
-      std::string color;
-      std::string status;
-      if (read_status) {
-        status = "Enabled";
-        color = "color:green";
-      } else {
-        status = "Disabled";
-        color = "color:red";
-      }
-      TMBFiberReset = toolbox::toString("/%s/TMBFiberReset",
-        getApplicationDescriptor()->getURN().c_str());
-      *out << cgicc::form().set("method", "GET").set("action", TMBFiberReset);
-      *out << cgicc::input().set("type", "submit").set("value", status).set("style", color);
-      sprintf(buf, "%d", tmb);
-      *out << cgicc::input().set("type", "hidden").set("value", buf).set("name", "tmb");
-      *out << cgicc::input().set("type", "hidden").set("value", "toggle").set("name", "mode");
-      *out << cgicc::input().set("type", "hidden").set("value", fiber_num).set("name", "fiber");
-      *out << cgicc::form() << std::endl;
-    } else {
-      *out << "N/A";
-    }
-    //
-    *out << cgicc::td();
-    *out << cgicc::td();
-    //
-    TMBFiberReset = toolbox::toString("/%s/TMBFiberReset", getApplicationDescriptor()->getURN().c_str());
+
+  if (thisTMB->GetHardwareVersion()==2) {
+    std::string TMBFiberReset = toolbox::toString("/%s/TMBFiberReset",
+						  getApplicationDescriptor()->getURN().c_str());
     *out << cgicc::form().set("method", "GET").set("action", TMBFiberReset);
-    *out << cgicc::input().set("type", "submit").set("value", "Reset");
+    *out << cgicc::input().set("type", "submit").set("value", "Read GTX Fiber Status");
     sprintf(buf, "%d", tmb);
-    *out << cgicc::input().set("type", "hidden").set("value", buf).set("name", "tmb");
-    *out << cgicc::input().set("type", "hidden").set("value", "reset").set("name", "mode");
-    *out << cgicc::input().set("type", "hidden").set("value", fiber_num).set("name", "fiber");
+    *out
+      << cgicc::input().set("type", "hidden").set("value", buf).set("name",
+								    "tmb");
+    *out
+      << cgicc::input().set("type", "hidden").set("value", "read").set("name",
+								       "mode");
     *out << cgicc::form() << std::endl;
     //
+    *out << cgicc::table().set("border", "1");
+    *out << cgicc::tr();
+    *out << cgicc::td();
+    *out << "Fiber";
+    *out << cgicc::td();
+    *out << cgicc::td();
+    *out << "Status/Toggle";
+    *out << cgicc::td();
+    *out << cgicc::td();
+    *out << "Reset";
     *out << cgicc::td();
     *out << cgicc::tr();
-    std::stringstream ss;
-    ss << i + 1;
-    fiber_num = ss.str();
-  }
-  *out << cgicc::table();
+    std::string fiber_num = "all";
+    for (int i = -1; i < ((int) TMB_N_FIBERS); ++i) {
+      *out << cgicc::tr();
+      *out << cgicc::td();
+      *out << fiber_num;
+      *out << cgicc::td();
+      *out << cgicc::td();
+      //
+      if (tmb_fiber_status_read_) {
+	bool read_status = false;
+	if (i < 0) {
+	  read_status = thisTMB->GetReadGtxRxAllEnable();
+	} else {
+	  read_status = thisTMB->GetReadGtxRxEnable(i);
+	}
+	std::string color;
+	std::string status;
+	if (read_status) {
+	  status = "Enabled";
+	  color = "color:green";
+	} else {
+	  status = "Disabled";
+	  color = "color:red";
+	}
+	TMBFiberReset = toolbox::toString("/%s/TMBFiberReset",
+					  getApplicationDescriptor()->getURN().c_str());
+	*out << cgicc::form().set("method", "GET").set("action", TMBFiberReset);
+	*out << cgicc::input().set("type", "submit").set("value", status).set("style", color);
+	sprintf(buf, "%d", tmb);
+	*out << cgicc::input().set("type", "hidden").set("value", buf).set("name", "tmb");
+	*out << cgicc::input().set("type", "hidden").set("value", "toggle").set("name", "mode");
+	*out << cgicc::input().set("type", "hidden").set("value", fiber_num).set("name", "fiber");
+	*out << cgicc::form() << std::endl;
+      } else {
+	*out << "N/A";
+      }
+    //
+      *out << cgicc::td();
+      *out << cgicc::td();
+      //
+      TMBFiberReset = toolbox::toString("/%s/TMBFiberReset", getApplicationDescriptor()->getURN().c_str());
+      *out << cgicc::form().set("method", "GET").set("action", TMBFiberReset);
+      *out << cgicc::input().set("type", "submit").set("value", "Reset");
+      sprintf(buf, "%d", tmb);
+      *out << cgicc::input().set("type", "hidden").set("value", buf).set("name", "tmb");
+      *out << cgicc::input().set("type", "hidden").set("value", "reset").set("name", "mode");
+      *out << cgicc::input().set("type", "hidden").set("value", fiber_num).set("name", "fiber");
+      *out << cgicc::form() << std::endl;
+      //
+      *out << cgicc::td();
+      *out << cgicc::tr();
+      std::stringstream ss;
+      ss << i + 1;
+      fiber_num = ss.str();
+    }
+    *out << cgicc::table();
+  }// GTX monitor for OTMB
 
   //
   //--------------------------------------------------------
@@ -10616,7 +10619,7 @@ void EmuPeripheralCrateConfig::LoadCrateTMBFirmware(xgi::Input * in, xgi::Output
   // Create a TMB which all TMB's within a crate will listen to....
   //
   Chamber * thisChamber = new Chamber(thisCrate);  // a dummy chamber
-  TMB * thisTMB = new TMB(thisCrate, thisChamber, 26); // must use a dummy chamber, not a real one
+  TMB * thisTMB = new TMB(thisCrate, thisChamber, 26, 0); // must use a dummy chamber, not a real one
   //
   tmb_vme_ready = -1;
   //

--- a/emuDCS/PeripheralApps/src/common/XMLParser.cc
+++ b/emuDCS/PeripheralApps/src/common/XMLParser.cc
@@ -336,13 +336,15 @@ void XMLParser::TMBParser(xercesc::DOMNode * pNode, Crate * theCrate, Chamber * 
     std::cerr << "No slot specified for TMB! " << std::endl;
   } else {
     //
-    TMB * tmb_ = new TMB(theCrate, theChamber, slot);
+    int value;
+    int tmbHwVersion = 0;
+    if (fillInt("hardware_version", value)) { tmbHwVersion = value;  }     
+
+    TMB * tmb_ = new TMB(theCrate, theChamber, slot, tmbHwVersion);
     //
     // need still to put in 
     //   . ddd_oe mask
-    int value;
 
-    if (fillInt("hardware_version", value)) { tmb_->SetHardwareVersion(value);  }     
               
     //////////////////////////////
     // Expected Firmware tags:

--- a/emuDCS/PeripheralApps/src/common/XMLParser.cc
+++ b/emuDCS/PeripheralApps/src/common/XMLParser.cc
@@ -622,6 +622,15 @@ void XMLParser::TMBParser(xercesc::DOMNode * pNode, Crate * theCrate, Chamber * 
     if (fillInt("cfeb6delay"     ,value)) { tmb_->SetCfeb6RxClockDelay(value); }
     if (fillInt("cfeb6posneg",value))     { tmb_->SetCfeb6RxPosNeg(value);     }
     //
+    //
+    //0X16A
+    if (fillInt("cfeb456delay"     ,value)) { tmb_->SetCfeb456RxClockDelay(value); }
+    if (fillInt("cfeb456posneg",value))     { tmb_->SetCfeb456RxPosNeg(value);     }
+    //
+    //0X16C
+    if (fillInt("cfeb0123delay"     ,value)) { tmb_->SetCfeb0123RxClockDelay(value); }
+    if (fillInt("cfeb0123posneg",value))     { tmb_->SetCfeb0123RxPosNeg(value);     }
+    //
     //0X11C
     if (fillInt("cfeb0_rxd_int_delay",value)) { tmb_->SetCFEB0RxdIntDelay(value); }
     if (fillInt("cfeb1_rxd_int_delay",value)) { tmb_->SetCFEB1RxdIntDelay(value); }

--- a/emuDCS/PeripheralCore/include/emu/pc/DAQMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/DAQMB.h
@@ -580,7 +580,7 @@ public:
   void halfset(int icrd,int ipln,int ihalf,int chan[][6][16]);
   void halfset(int icrd,int ipln,int ihalf);
   void trigsetx(int *hp,int CFEBInputs=0x1f);
-  void chan2shift(int chan[][6][16]);
+  void chan2shift(int chan[][6][16], bool debug=false);
   void buck_shift_ext_bc(int nstrip);
   void buck_shift_comp_bc(int nstrip);
 

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -430,7 +430,7 @@ public:
   //friend class TMBParser;
   friend class EMUjtag;
   //
-  explicit TMB(Crate * , Chamber *, int );
+  explicit TMB(Crate * , Chamber *, int, int );
   virtual ~TMB();
   //
   //
@@ -501,7 +501,7 @@ public:
   void SetALCTPatternTrigger();
   void SetCLCTPatternTrigger();
   //
-  inline void SetHardwareVersion(int version) {hardware_version_ = version;}
+  //  inline void SetHardwareVersion(int version) {hardware_version_ = version;} //in TMB constructor now
   inline int GetHardwareVersion() {return hardware_version_;}
   //
   //!read the Firmware date from the TMB

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -1943,30 +1943,79 @@ public:
   inline int  GetReadCfeb4RxPosNeg() { return read_cfeb4_rx_posneg_; }
   //
   //---------------------------------------------------------------------
-  //0X16A = ADR_V6_PHASER7 digital phase shifter setting for cfeb5_rx
+  //0X16A = ADR_V6_PHASER7 digital phase shifter setting for A side dcfebs - cfeb456_rx
   //---------------------------------------------------------------------
   inline void SetCfeb5RxClockDelay(int cfeb5_rx_clock_delay) { cfeb5_rx_clock_delay_ = cfeb5_rx_clock_delay; }
+  inline void SetCfeb456RxClockDelay(int cfeb456_rx_clock_delay) { 
+    cfeb4_rx_clock_delay_ = cfeb456_rx_clock_delay; 
+    cfeb5_rx_clock_delay_ = cfeb456_rx_clock_delay; 
+    cfeb6_rx_clock_delay_ = cfeb456_rx_clock_delay; 
+    cfeb456_rx_clock_delay_ = cfeb456_rx_clock_delay; 
+  }
   inline void SetCFEB5delay(int cfeb5_rx_clock_delay)        { cfeb5_rx_clock_delay_ = cfeb5_rx_clock_delay; } //legacy setter
+  inline void SetCFEB456delay(int cfeb456_rx_clock_delay)        { 
+    cfeb4_rx_clock_delay_ = cfeb456_rx_clock_delay; 
+    cfeb5_rx_clock_delay_ = cfeb456_rx_clock_delay; 
+    cfeb6_rx_clock_delay_ = cfeb456_rx_clock_delay; 
+    cfeb456_rx_clock_delay_ = cfeb456_rx_clock_delay; 
+  } //legacy setter
   inline int  GetCfeb5RxClockDelay() { return cfeb5_rx_clock_delay_; }
+  inline int  GetCfeb456RxClockDelay() { return cfeb456_rx_clock_delay_; }
   inline int  GetCFEB5delay()        { return cfeb5_rx_clock_delay_; } //legacy getter
+  inline int  GetCFEB456delay()        { return cfeb456_rx_clock_delay_; } //legacy getter
   inline int  GetReadCfeb5RxClockDelay() { return read_cfeb5_rx_clock_delay_; }
+  inline int  GetReadCfeb456RxClockDelay() { return read_cfeb456_rx_clock_delay_; }
   //
   inline void SetCfeb5RxPosNeg(int cfeb5_rx_posneg) { cfeb5_rx_posneg_ = cfeb5_rx_posneg; }
+  inline void SetCfeb456RxPosNeg(int cfeb456_rx_posneg) { 
+    cfeb4_rx_posneg_ = cfeb456_rx_posneg; 
+    cfeb5_rx_posneg_ = cfeb456_rx_posneg; 
+    cfeb6_rx_posneg_ = cfeb456_rx_posneg; 
+    cfeb456_rx_posneg_ = cfeb456_rx_posneg; 
+  }
   inline int  GetCfeb5RxPosNeg() { return cfeb5_rx_posneg_; }
+  inline int  GetCfeb456RxPosNeg() { return cfeb456_rx_posneg_; }
   inline int  GetReadCfeb5RxPosNeg() { return read_cfeb5_rx_posneg_; }
+  inline int  GetReadCfeb456RxPosNeg() { return read_cfeb456_rx_posneg_; }
   //
   //---------------------------------------------------------------------
-  //0X16C = ADR_V6_PHASER8 digital phase shifter setting for cfeb6_rx
+  //0X16C = ADR_V6_PHASER8 digital phase shifter setting for B side dcfebs - cfeb0123_rx
   //---------------------------------------------------------------------
   inline void SetCfeb6RxClockDelay(int cfeb6_rx_clock_delay) { cfeb6_rx_clock_delay_ = cfeb6_rx_clock_delay; }
+  inline void SetCfeb0123RxClockDelay(int cfeb0123_rx_clock_delay) { 
+    cfeb0_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
+    cfeb1_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
+    cfeb2_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
+    cfeb3_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
+    cfeb0123_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
+  }
   inline void SetCFEB6delay(int cfeb6_rx_clock_delay)        { cfeb6_rx_clock_delay_ = cfeb6_rx_clock_delay; } //legacy setter
+  inline void SetCFEB0123delay(int cfeb0123_rx_clock_delay)        { 
+    cfeb0_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
+    cfeb1_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
+    cfeb2_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
+    cfeb3_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
+    cfeb0123_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
+  } //legacy setter
   inline int  GetCfeb6RxClockDelay() { return cfeb6_rx_clock_delay_; }
+  inline int  GetCfeb0123RxClockDelay() { return cfeb0123_rx_clock_delay_; }
   inline int  GetCFEB6delay()        { return cfeb6_rx_clock_delay_; } //legacy getter
+  inline int  GetCFEB0123delay()        { return cfeb0123_rx_clock_delay_; } //legacy getter
   inline int  GetReadCfeb6RxClockDelay() { return read_cfeb6_rx_clock_delay_; }
+  inline int  GetReadCfeb0123RxClockDelay() { return read_cfeb0123_rx_clock_delay_; }
   //
   inline void SetCfeb6RxPosNeg(int cfeb6_rx_posneg) { cfeb6_rx_posneg_ = cfeb6_rx_posneg; }
+  inline void SetCfeb0123RxPosNeg(int cfeb0123_rx_posneg) { 
+    cfeb0_rx_posneg_ = cfeb0123_rx_posneg; 
+    cfeb1_rx_posneg_ = cfeb0123_rx_posneg; 
+    cfeb2_rx_posneg_ = cfeb0123_rx_posneg; 
+    cfeb3_rx_posneg_ = cfeb0123_rx_posneg; 
+    cfeb0123_rx_posneg_ = cfeb0123_rx_posneg; 
+  }
   inline int  GetCfeb6RxPosNeg() { return cfeb6_rx_posneg_; }
+  inline int  GetCfeb0123RxPosNeg() { return cfeb0123_rx_posneg_; }
   inline int  GetReadCfeb6RxPosNeg() { return read_cfeb6_rx_posneg_; }
+  inline int  GetReadCfeb0123RxPosNeg() { return read_cfeb0123_rx_posneg_; }
   //
   //---------------------------------------------------------------------
   // 0X11C = ADR_DELAY0_INT:  CFEB to TMB "interstage" delays
@@ -3428,21 +3477,29 @@ private:
   //
   //
   //--------------------------------------------------------------
-  //[0X16A] = ADR_V6_PHASER7:  values in the xml file for cfeb5_rx
+  //[0X16A] = ADR_V6_PHASER7:  values in the xml file for A side dcfebs - cfeb456_rx
   //--------------------------------------------------------------
+  int cfeb456_rx_clock_delay_ ;
+  int cfeb456_rx_posneg_;
   int cfeb5_rx_clock_delay_ ;
   int cfeb5_rx_posneg_;
   //
+  int read_cfeb456_rx_clock_delay_ ;
+  int read_cfeb456_rx_posneg_;
   int read_cfeb5_rx_clock_delay_ ;
   int read_cfeb5_rx_posneg_;
   //
   //
   //--------------------------------------------------------------
-  //[0X16C] = ADR_V6_PHASER8:  values in the xml file for cfeb6_rx
+  //[0X16C] = ADR_V6_PHASER8:  values in the xml file for B side dcfebs - cfeb0123_rx
   //--------------------------------------------------------------
+  int cfeb0123_rx_clock_delay_ ;
+  int cfeb0123_rx_posneg_;
   int cfeb6_rx_clock_delay_ ;
   int cfeb6_rx_posneg_;
   //
+  int read_cfeb0123_rx_clock_delay_ ;
+  int read_cfeb0123_rx_posneg_;
   int read_cfeb6_rx_clock_delay_ ;
   int read_cfeb6_rx_posneg_;
   //

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
@@ -336,8 +336,8 @@ static const unsigned long int  badbits601_adr          = 0x000164;  //ADR_V6_CF
 static const unsigned long int  badbits623_adr          = 0x000166;  //ADR_V6_CFEB6_BADBITS_LY23
 static const unsigned long int  badbits645_adr          = 0x000168;  //ADR_V6_CFEB6_BADBITS_LY45
 
-static const unsigned long int  phaser_cfeb5_rxd_adr	= 0x00016A;  
-static const unsigned long int  phaser_cfeb6_rxd_adr	= 0x00016C;
+static const unsigned long int  phaser_cfeb456_rxd_adr	 = 0x00016A;  
+static const unsigned long int  phaser_cfeb0123_rxd_adr = 0x00016C;
 
 // extra DCFEB Hot Channel Mask on OTMB
 static const unsigned long int  hcm501_adr              = 0x00016E;
@@ -2382,18 +2382,32 @@ const int cfeb4_rx_clock_delay_default  =  3;                   //default value 
 const int cfeb4_rx_posneg_default       =  0; 
 //
 //--------------------------------------------------------------
-//[0X16A] = ADR_PHASER6:  values in the xml file for cfeb5_rx
+//[0X16A] = ADR_PHASER7:  values in the xml file for cfeb5_rx
 //--------------------------------------------------------------
-const int cfeb5_rx_clock_delay_vmereg   =  phaser_cfeb5_rxd_adr;
+const int cfeb5_rx_clock_delay_vmereg   =  phaser_cfeb456_rxd_adr; // for compatibility, will be removed
 const int cfeb5_rx_clock_delay_default  =  3;                   //default value in nanoseconds (not the VME register values) 
 const int cfeb5_rx_posneg_default       =  0; 
 //
 //--------------------------------------------------------------
-//[0X16C] = ADR_PHASER6:  values in the xml file for cfeb6_rx
+//[0X16C] = ADR_PHASER8:  values in the xml file for cfeb6_rx
 //--------------------------------------------------------------
-const int cfeb6_rx_clock_delay_vmereg   =  phaser_cfeb6_rxd_adr;
+const int cfeb6_rx_clock_delay_vmereg   =  phaser_cfeb456_rxd_adr; // for compatibility, will be removed
 const int cfeb6_rx_clock_delay_default  =  3;                   //default value in nanoseconds (not the VME register values) 
 const int cfeb6_rx_posneg_default       =  0; 
+//
+//--------------------------------------------------------------
+//[0X16C] = ADR_PHASER7:  values in the xml file for cfeb0123_rx
+//--------------------------------------------------------------
+const int cfeb0123_rx_clock_delay_vmereg   =  phaser_cfeb0123_rxd_adr;
+const int cfeb0123_rx_clock_delay_default  =  3;                   //default value in nanoseconds (not the VME register values) 
+const int cfeb0123_rx_posneg_default       =  0; 
+//
+//--------------------------------------------------------------
+//[0X16C] = ADR_PHASER8:  values in the xml file for cfeb456_rx
+//--------------------------------------------------------------
+const int cfeb456_rx_clock_delay_vmereg   =  phaser_cfeb456_rxd_adr;
+const int cfeb456_rx_clock_delay_default  =  3;                   //default value in nanoseconds (not the VME register values) 
+const int cfeb456_rx_posneg_default       =  0; 
 //
 //---------------------------------------------------------------------
 // 0X11C = ADR_DELAY0_INT:  CFEB to TMB "interstage" delays

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
@@ -313,7 +313,6 @@ static const unsigned long int	badbits401_adr	        = 0x00013E;
 static const unsigned long int	badbits423_adr	        = 0x000140;
 static const unsigned long int	badbits445_adr	        = 0x000142;
 
-static const unsigned long int	v6_sysmon_adr	        = 0x00015A;  //ADR_V6_SYSMON
 static const unsigned long int	alct_startup_status_adr = 0x000146; //ADR_ALCT_STARTUP_STATUS
 static const unsigned long int	v6_snap12_qpll_adr      = 0x000148; //ADR_V6_SNAP12_QPLL
 
@@ -326,6 +325,8 @@ static const unsigned long int  v6_gtx_rx3_adr          = 0x000152;  //ADR_V6_GT
 static const unsigned long int  v6_gtx_rx4_adr          = 0x000154;  //ADR_V6_GTX_RX4
 static const unsigned long int  v6_gtx_rx5_adr          = 0x000156;  //ADR_V6_GTX_RX5
 static const unsigned long int  v6_gtx_rx6_adr          = 0x000158;  //ADR_V6_GTX_RX6
+
+static const unsigned long int	v6_sysmon_adr	        = 0x00015A;  //ADR_V6_SYSMON
 
 // extra DCFEB Bad Bits on OTMB 
 static const unsigned long int  dcfeb_badbits_ctrl_adr  = 0x00015C;  //DCFEB Bad Bit Control/Status extends Adr 122

--- a/emuDCS/PeripheralCore/src/common/DAQMB.cc
+++ b/emuDCS/PeripheralCore/src/common/DAQMB.cc
@@ -1893,7 +1893,7 @@ void DAQMB::dcfeb_buck_shift_comp_bc(int nstrip)
   ::usleep(200);
 }
 
-void DAQMB::chan2shift(int chan[5][6][16])
+void DAQMB::chan2shift(int chan[5][6][16], bool debug)
 {
    
    int i,j;
@@ -1908,19 +1908,21 @@ void DAQMB::chan2shift(int chan[5][6][16])
    //
    //   (*MyOutput_) << std::endl;
    
-   for(lay=0;lay<6;lay++){
-      for(unsigned icfeb = 0; icfeb < cfebs_.size(); ++icfeb) {
+   if (debug){
+     for(lay=0;lay<6;lay++){
+       for(unsigned icfeb = 0; icfeb < cfebs_.size(); ++icfeb) {
 	 int brdn = cfebs_[icfeb].number();
 	 for(int i=0; i<16;i++) {
 	   // if ( chan[brdn][lay][i] > 0 ) printf("%c", '\033');
-	    (*MyOutput_) << chan[brdn][lay][i] << "" ;
-	    //  printf("%c", '\033'); 
+	   (*MyOutput_) << chan[brdn][lay][i] << "" ;
+	   //  printf("%c", '\033'); 
 	 }
 	 (*MyOutput_) << " | " ;		
-      }
-      (*MyOutput_) << std::endl;
-   }
-   
+       }
+       (*MyOutput_) << std::endl;
+     }
+   }     
+
    for(unsigned icfeb = 0; icfeb < cfebs_.size(); ++icfeb) {
       DEVTYPE dv   = cfebs_[icfeb].scamDevice() ;
       int brdn = cfebs_[icfeb].number();

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -559,7 +559,7 @@ namespace emu {
   namespace pc {
 
 
-TMB::TMB(Crate * theCrate, Chamber * theChamber, int slot) :
+    TMB::TMB(Crate * theCrate, Chamber * theChamber, int slot, int hardware_version) :
   VMEModule(theCrate, slot),
   EMUjtag(this),
   EmuLogger(),
@@ -567,7 +567,7 @@ TMB::TMB(Crate * theCrate, Chamber * theChamber, int slot) :
   rat_(0),
   csc_(theChamber)
 {
-  hardware_version_=0;
+  hardware_version_=hardware_version;
   //
   debug_ = false;
   //
@@ -5391,8 +5391,8 @@ void TMB::DefineTMBConfigurationRegisters_(){
   TMBConfigurationRegister.push_back(phaser_cfeb2_rxd_adr);  //0x116 digital phase shifter: cfeb2_rx
   TMBConfigurationRegister.push_back(phaser_cfeb3_rxd_adr);  //0x118 digital phase shifter: cfeb3_rx
   TMBConfigurationRegister.push_back(phaser_cfeb4_rxd_adr);  //0x11A digital phase shifter: cfeb4_rx
-  TMBConfigurationRegister.push_back(phaser_cfeb5_rxd_adr);  //0x16A digital phase shifter: cfeb5_rx
-  TMBConfigurationRegister.push_back(phaser_cfeb6_rxd_adr);  //0x16C digital phase shifter: cfeb6_rx
+  TMBConfigurationRegister.push_back(phaser_cfeb5_rxd_adr);  //0x16A digital phase shifter: cfeb5_rx : ME1/1B side for OTMB
+  TMBConfigurationRegister.push_back(phaser_cfeb6_rxd_adr);  //0x16C digital phase shifter: cfeb6_rx : ME1/1A side for OTMB
   TMBConfigurationRegister.push_back(cfeb0_3_interstage_adr);//0x11C CFEB to TMB data delay: cfeb[0-3]
   TMBConfigurationRegister.push_back(cfeb4_6_interstage_adr);//0x11E CFEB to TMB data delay: cfeb[4-6]
   //
@@ -5425,6 +5425,9 @@ void TMB::DefineTMBConfigurationRegisters_(){
   //
   // Automatic masking of bad bits
   TMBConfigurationRegister.push_back(cfeb_badbits_ctrl_adr) ;  //0x122
+  if (hardware_version_ >= 2){
+    TMBConfigurationRegister.push_back(dcfeb_badbits_ctrl_adr) ;  //0x15C
+  }
   //
   // GTX link control and monitoring
   //TMBConfigurationRegister.push_back(v6_gtx_rx0_adr) ;  //0x14C GTX link control and monitoring for DCFEB0

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -5391,8 +5391,8 @@ void TMB::DefineTMBConfigurationRegisters_(){
   TMBConfigurationRegister.push_back(phaser_cfeb2_rxd_adr);  //0x116 digital phase shifter: cfeb2_rx
   TMBConfigurationRegister.push_back(phaser_cfeb3_rxd_adr);  //0x118 digital phase shifter: cfeb3_rx
   TMBConfigurationRegister.push_back(phaser_cfeb4_rxd_adr);  //0x11A digital phase shifter: cfeb4_rx
-  TMBConfigurationRegister.push_back(phaser_cfeb5_rxd_adr);  //0x16A digital phase shifter: cfeb5_rx : ME1/1B side for OTMB
-  TMBConfigurationRegister.push_back(phaser_cfeb6_rxd_adr);  //0x16C digital phase shifter: cfeb6_rx : ME1/1A side for OTMB
+  TMBConfigurationRegister.push_back(phaser_cfeb456_rxd_adr);  //0x16A digital phase shifter: cfeb456_rx; can serve for #5 for bw compatibility
+  TMBConfigurationRegister.push_back(phaser_cfeb0123_rxd_adr); //0x16C digital phase shifter: cfeb0123_rx; can serve for #6 for bw compatibility
   TMBConfigurationRegister.push_back(cfeb0_3_interstage_adr);//0x11C CFEB to TMB data delay: cfeb[0-3]
   TMBConfigurationRegister.push_back(cfeb4_6_interstage_adr);//0x11E CFEB to TMB data delay: cfeb[4-6]
   //
@@ -6634,8 +6634,8 @@ void TMB::DecodeTMBRegister_(unsigned long int address, int data) {
 	      address == phaser_cfeb2_rxd_adr ||
 	      address == phaser_cfeb3_rxd_adr ||
 	      address == phaser_cfeb4_rxd_adr || 
-	      address == phaser_cfeb5_rxd_adr ||
-	      address == phaser_cfeb6_rxd_adr) {    
+	      address == phaser_cfeb456_rxd_adr ||
+	      address == phaser_cfeb0123_rxd_adr) {    
     //---------------------------------------------------------------------
     //(0X10E,0X110,0X112,0X114,0X116,0X118,0X11A) = ADR_PHASER[0-6]:  
     // digital phase shifter for... alct_rx,alct_tx,cfeb[0-4]_rx
@@ -7645,21 +7645,21 @@ void TMB::PrintTMBRegister(unsigned long int address) {
     (*MyOutput_) << "    CFEB4 rx clock delay    = " << std::dec << read_cfeb4_rx_clock_delay_ << std::endl;
     (*MyOutput_) << "    CFEB4 posneg    = " << std::dec << read_cfeb4_rx_posneg_ << std::endl;
     //
-  } else if ( address == phaser_cfeb5_rxd_adr ) {
+  } else if ( address == phaser_cfeb456_rxd_adr ) {
     //--------------------------------------------------------------
-    //[0X16A] = ADR_PHASER7:  CFEB5 -> TMB communication clock delay
+    //[0X16A] = ADR_PHASER7:  CFEB456 -> TMB communication clock delay
     //--------------------------------------------------------------
-    (*MyOutput_) << " ->CFEB5 to TMB communication clock delay:" << std::endl;
-    (*MyOutput_) << "    CFEB5 rx clock delay    = " << std::dec << read_cfeb5_rx_clock_delay_ << std::endl;
-    (*MyOutput_) << "    CFEB5 posneg    = " << std::dec << read_cfeb5_rx_posneg_ << std::endl;
+    (*MyOutput_) << " ->CFEB456 to TMB communication clock delay:" << std::endl;
+    (*MyOutput_) << "    CFEB456 rx clock delay    = " << std::dec << read_cfeb456_rx_clock_delay_ << std::endl;
+    (*MyOutput_) << "    CFEB456 posneg    = " << std::dec << read_cfeb456_rx_posneg_ << std::endl;
     //
-  } else if ( address == phaser_cfeb6_rxd_adr ) {
+  } else if ( address == phaser_cfeb0123_rxd_adr ) {
     //--------------------------------------------------------------
-    //[0X16C] = ADR_PHASER8:  CFEB6 -> TMB communication clock delay
+    //[0X16C] = ADR_PHASER8:  CFEB0123 -> TMB communication clock delay
     //--------------------------------------------------------------
-    (*MyOutput_) << " ->CFEB6 to TMB communication clock delay:" << std::endl;
-    (*MyOutput_) << "    CFEB6 rx clock delay    = " << std::dec << read_cfeb6_rx_clock_delay_ << std::endl;
-    (*MyOutput_) << "    CFEB6 posneg    = " << std::dec << read_cfeb6_rx_posneg_ << std::endl;	
+    (*MyOutput_) << " ->CFEB0123 to TMB communication clock delay:" << std::endl;
+    (*MyOutput_) << "    CFEB0123 rx clock delay    = " << std::dec << read_cfeb0123_rx_clock_delay_ << std::endl;
+    (*MyOutput_) << "    CFEB0123 posneg    = " << std::dec << read_cfeb0123_rx_posneg_ << std::endl;	
     //
   } else if ( address == cfeb0_3_interstage_adr ) {
     //--------------------------------------------------------------
@@ -8343,17 +8343,17 @@ int TMB::FillTMBRegister(unsigned long int address) {
     //---------------------------------------------------------------------
     data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb4_rx_clock_delay_,cfeb4_rx_posneg_);
     //
-  } else if ( address == phaser_cfeb5_rxd_adr ) {
+  } else if ( address == phaser_cfeb456_rxd_adr ) {
     //---------------------------------------------------------------------
-    //0X11A = ADR_PHASER7: digital phase shifter for cfeb5
+    //0X11A = ADR_PHASER7: digital phase shifter for cfeb456
     //---------------------------------------------------------------------
-    data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb5_rx_clock_delay_,cfeb5_rx_posneg_);
+    data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb456_rx_clock_delay_,cfeb456_rx_posneg_);
     //
-  } else if ( address == phaser_cfeb6_rxd_adr ) {
+  } else if ( address == phaser_cfeb0123_rxd_adr ) {
     //---------------------------------------------------------------------
-    //0X11A = ADR_PHASER8: digital phase shifter for cfeb6
+    //0X11A = ADR_PHASER8: digital phase shifter for cfeb0123
     //---------------------------------------------------------------------
-    data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb6_rx_clock_delay_,cfeb6_rx_posneg_);
+    data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb0123_rx_clock_delay_,cfeb0123_rx_posneg_);
     //
   } else if ( address == cfeb0_3_interstage_adr ) {    
     //---------------------------------------------------------------------
@@ -8514,15 +8514,29 @@ void TMB::ConvertVMERegisterValuesToDigitalPhases_(unsigned long int vme_address
     read_cfeb4_rx_posneg_      = posneg       ;
     read_cfeb4_rx_clock_delay_ = read_digital_phase;
     //
-  } else if ( vme_address == phaser_cfeb5_rxd_adr ) {
+  } else if ( vme_address == phaser_cfeb456_rxd_adr ) {
     //
+    read_cfeb4_rx_posneg_      = posneg       ;
+    read_cfeb4_rx_clock_delay_ = read_digital_phase;
     read_cfeb5_rx_posneg_      = posneg       ;
     read_cfeb5_rx_clock_delay_ = read_digital_phase;
-    //
-  } else if ( vme_address == phaser_cfeb6_rxd_adr ) {
-    //
     read_cfeb6_rx_posneg_      = posneg       ;
     read_cfeb6_rx_clock_delay_ = read_digital_phase;
+    read_cfeb456_rx_posneg_      = posneg       ;
+    read_cfeb456_rx_clock_delay_ = read_digital_phase;
+    //
+  } else if ( vme_address == phaser_cfeb0123_rxd_adr ) {
+    //
+    read_cfeb0_rx_posneg_      = posneg       ;
+    read_cfeb0_rx_clock_delay_ = read_digital_phase;
+    read_cfeb1_rx_posneg_      = posneg       ;
+    read_cfeb1_rx_clock_delay_ = read_digital_phase;
+    read_cfeb2_rx_posneg_      = posneg       ;
+    read_cfeb2_rx_clock_delay_ = read_digital_phase;
+    read_cfeb3_rx_posneg_      = posneg       ;
+    read_cfeb3_rx_clock_delay_ = read_digital_phase;
+    read_cfeb0123_rx_posneg_      = posneg       ;
+    read_cfeb0123_rx_clock_delay_ = read_digital_phase;
     //
   }
   //

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -8426,6 +8426,13 @@ int TMB::FillTMBRegister(unsigned long int address) {
     InsertValueIntoDataWord(gtx_rx_reset_[inputNum],gtx_rx_reset_bithi,gtx_rx_reset_bitlo,&data_word);
     InsertValueIntoDataWord(gtx_rx_prbs_test_enable_[inputNum],gtx_rx_prbs_test_enable_bithi,gtx_rx_prbs_test_enable_bitlo,&data_word);
     //
+  } else if ( address == dcfeb_badbits_ctrl_adr) {
+    //-------------------------------------------------------------------------------
+    // 0X15C = ADR_V6_CFEB_BADBITS_CTRL CFEB Bad Bits Control/Status (See Adr 0x122)
+    //-------------------------------------------------------------------------------
+    InsertValueIntoDataWord(dcfeb_badbits_reset_  ,dcfeb_badbits_reset_bithi  ,dcfeb_badbits_reset_bitlo  ,&data_word);
+    InsertValueIntoDataWord(dcfeb_badbits_block_  ,dcfeb_badbits_block_bithi  ,dcfeb_badbits_block_bitlo  ,&data_word);
+    //
   } else {
     //
     (*MyOutput_) << "TMB: ERROR in FillTMBRegister, VME address = " << address << " not supported to be filled" << std::endl;

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -8343,18 +8343,6 @@ int TMB::FillTMBRegister(unsigned long int address) {
     //---------------------------------------------------------------------
     data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb4_rx_clock_delay_,cfeb4_rx_posneg_);
     //
-  } else if ( address == phaser_cfeb456_rxd_adr ) {
-    //---------------------------------------------------------------------
-    //0X11A = ADR_PHASER7: digital phase shifter for cfeb456
-    //---------------------------------------------------------------------
-    data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb456_rx_clock_delay_,cfeb456_rx_posneg_);
-    //
-  } else if ( address == phaser_cfeb0123_rxd_adr ) {
-    //---------------------------------------------------------------------
-    //0X11A = ADR_PHASER8: digital phase shifter for cfeb0123
-    //---------------------------------------------------------------------
-    data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb0123_rx_clock_delay_,cfeb0123_rx_posneg_);
-    //
   } else if ( address == cfeb0_3_interstage_adr ) {    
     //---------------------------------------------------------------------
     // 0X11C = ADR_DELAY0_INT:  CFEB to TMB "interstage" delays
@@ -8432,6 +8420,18 @@ int TMB::FillTMBRegister(unsigned long int address) {
     //-------------------------------------------------------------------------------
     InsertValueIntoDataWord(dcfeb_badbits_reset_  ,dcfeb_badbits_reset_bithi  ,dcfeb_badbits_reset_bitlo  ,&data_word);
     InsertValueIntoDataWord(dcfeb_badbits_block_  ,dcfeb_badbits_block_bithi  ,dcfeb_badbits_block_bitlo  ,&data_word);
+    //
+  } else if ( address == phaser_cfeb456_rxd_adr ) {
+    //---------------------------------------------------------------------
+    //0X16A = ADR_PHASER7: digital phase shifter for cfeb456
+    //---------------------------------------------------------------------
+    data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb456_rx_clock_delay_,cfeb456_rx_posneg_);
+    //
+  } else if ( address == phaser_cfeb0123_rxd_adr ) {
+    //---------------------------------------------------------------------
+    //0X16C = ADR_PHASER8: digital phase shifter for cfeb0123
+    //---------------------------------------------------------------------
+    data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb0123_rx_clock_delay_,cfeb0123_rx_posneg_);
     //
   } else {
     //


### PR DESCRIPTION
- CFEB comparator RX delays for A and B side (from David Morse)
  - changes affect only OTMB
  - the old CFEB5 phaser control register now serves ME1/1 side A (CFEBs 4,5,6)
  - the old CFEB6 phaser control register now serves ME1/1 side B (CFEBs 0,1,2,3)
  - the old interface to the comparator RX phasers of TMB.h is left in place: Set and Get methods remain, but the RX settings may be undefined for updated applications communicating with OTMB FW older than (01/20/2015 - c) or for not updated applications communicating for any OTMB FW version.
  - (SK) the CFEB RX scan per chamber allows a choice to use ME11 A and B parts grouped or to keep the old setup with 7 phasers; this is hardcoded in per-crate/per-system scans with the default to be "grouped", if there is a delay in uploading the firmware, we can just change the default easily and recompile to have the 7-phaser case still work
- 2D scan array is now filled in ChamberUtilities (from David Morse)
- don't display GTX utilities interface for TMB, only OTMB
- put dcfeb_badbits_ctrl_adr in the config registers
- add TMB hardware version to the class constructor and remove the SetHardwareVersion method (all available use cases in TriDAS/emu were updated; others will just not compile and will be easy to fix)
- in DAQMB: made chan2shift less verbose by default; the printout can be enabled again by passing the debug bool.
