### PR TITLE
cfeb{0123,456} RX config parameters

### DIFF
--- a/emuDCS/PeripheralApps/include/emu/pc/ChamberUtilities.h
+++ b/emuDCS/PeripheralApps/include/emu/pc/ChamberUtilities.h
@@ -64,7 +64,7 @@ public:
   void CFEBTiming();                           //default is normal_scan
   void CFEBTiming(CFEBTiming_scanType);
   void CFEBTiming_with_Posnegs_simple_routine(int time_delay, int cfeb_num, unsigned int layers, unsigned int pattern, 
-					      int halfstrip, bool print_data, int cfeb_clock_phase, bool groupME11AandB);
+					      int halfstrip, bool print_data, int cfeb_clock_phase);
   void CFEBTiming_with_Posnegs(CFEBTiming_scanType);
   void CFEBTiming_without_Posnegs();
   //
@@ -143,7 +143,6 @@ public:
     int tmb_l1a_delay;
     int cfeb_rx_posneg;
     int cfeb_rx_clock_delay;
-    bool groupME11AandB;
     
     int cfeb_mask;
     
@@ -169,8 +168,7 @@ public:
       cfeb_rx_posneg(0),
       cfeb_rx_clock_delay(0),
       cfeb_clock_phase(0),
-      cfeb_mask(0x7f),
-      groupME11AandB(false)
+      cfeb_mask(0x7f)
     {}
     
     inline CFEBTiming_Configuration(const CFEBTiming_Configuration & o):
@@ -194,8 +192,7 @@ public:
       cfeb_rx_posneg(o.cfeb_rx_posneg),
       cfeb_rx_clock_delay(o.cfeb_rx_clock_delay),
       cfeb_clock_phase(o.cfeb_clock_phase),
-      cfeb_mask(o.cfeb_mask),
-      groupME11AandB(o.groupME11AandB)
+      cfeb_mask(o.cfeb_mask)
     {}
   };
 

--- a/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
+++ b/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
@@ -695,7 +695,7 @@ void ChamberUtilities::SetCfebRxPosNeg(int posneg) {
     thisTMB->SetCfeb5RxPosNeg(posneg);
     thisTMB->SetCfeb6RxPosNeg(posneg);
   }
-  if (thisTMB->GetHardwareVersion() == 1){
+  if (thisTMB->HasGroupedME11ABCFEBRxValues() == 1){
     thisTMB->SetCfeb0123RxPosNeg(posneg);
     thisTMB->SetCfeb456RxPosNeg(posneg);
   }
@@ -1693,24 +1693,30 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
       initial_cfeb_phase[2] = thisTMB->GetReadCfeb2RxClockDelay();
       initial_cfeb_phase[3] = thisTMB->GetReadCfeb3RxClockDelay();
       initial_cfeb_phase[4] = thisTMB->GetReadCfeb4RxClockDelay();
-      initial_cfeb_phase[5] = thisTMB->GetReadCfeb5RxClockDelay();
-      initial_cfeb_phase[6] = thisTMB->GetReadCfeb6RxClockDelay();
+      if (thisTMB->HasGroupedME11ABCFEBRxValues() == 0){
+	initial_cfeb_phase[5] = thisTMB->GetReadCfeb5RxClockDelay();
+	initial_cfeb_phase[6] = thisTMB->GetReadCfeb6RxClockDelay();
+      }
       //
       initial_cfeb_posneg[0] = thisTMB->GetReadCfeb0RxPosNeg();
       initial_cfeb_posneg[1] = thisTMB->GetReadCfeb1RxPosNeg();
       initial_cfeb_posneg[2] = thisTMB->GetReadCfeb2RxPosNeg();
       initial_cfeb_posneg[3] = thisTMB->GetReadCfeb3RxPosNeg();
       initial_cfeb_posneg[4] = thisTMB->GetReadCfeb4RxPosNeg();
-      initial_cfeb_posneg[5] = thisTMB->GetReadCfeb5RxPosNeg();
-      initial_cfeb_posneg[6] = thisTMB->GetReadCfeb6RxPosNeg();
+      if (thisTMB->HasGroupedME11ABCFEBRxValues() == 0){
+	initial_cfeb_posneg[5] = thisTMB->GetReadCfeb5RxPosNeg();
+	initial_cfeb_posneg[6] = thisTMB->GetReadCfeb6RxPosNeg();
+      }
 
       initial_cfeb_rxd_int_delay[0] = thisTMB->GetCFEB0RxdIntDelay();
       initial_cfeb_rxd_int_delay[1] = thisTMB->GetCFEB1RxdIntDelay();
       initial_cfeb_rxd_int_delay[2] = thisTMB->GetCFEB2RxdIntDelay();
       initial_cfeb_rxd_int_delay[3] = thisTMB->GetCFEB3RxdIntDelay();
       initial_cfeb_rxd_int_delay[4] = thisTMB->GetCFEB4RxdIntDelay();
-      initial_cfeb_rxd_int_delay[5] = thisTMB->GetCFEB5RxdIntDelay();
-      initial_cfeb_rxd_int_delay[6] = thisTMB->GetCFEB6RxdIntDelay();
+      if (thisTMB->HasGroupedME11ABCFEBRxValues() == 0){
+	initial_cfeb_rxd_int_delay[5] = thisTMB->GetCFEB5RxdIntDelay();
+	initial_cfeb_rxd_int_delay[6] = thisTMB->GetCFEB6RxdIntDelay();
+      }
     } else {
       int initialPhase0123 = thisTMB->GetReadCfeb0123RxClockDelay();
       int initialPhase456 = thisTMB->GetReadCfeb456RxClockDelay();

--- a/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
+++ b/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
@@ -684,14 +684,18 @@ void ChamberUtilities::CFEBTiming_Configure(int * tof) {
 }
     
 void ChamberUtilities::SetCfebRxPosNeg(int posneg) {
-  thisTMB->SetCfeb0RxPosNeg(posneg);
-  thisTMB->SetCfeb1RxPosNeg(posneg);
-  thisTMB->SetCfeb2RxPosNeg(posneg);
-  thisTMB->SetCfeb3RxPosNeg(posneg);
-  thisTMB->SetCfeb4RxPosNeg(posneg);
-  thisTMB->SetCfeb5RxPosNeg(posneg);
-  thisTMB->SetCfeb6RxPosNeg(posneg);
-  if (thisTMB->GetHardwareVersion()>=2){
+  if (thisTMB->HasGroupedME11ABCFEBRxValues() <= 0){
+    thisTMB->SetCfeb0RxPosNeg(posneg);
+    thisTMB->SetCfeb1RxPosNeg(posneg);
+    thisTMB->SetCfeb2RxPosNeg(posneg);
+    thisTMB->SetCfeb3RxPosNeg(posneg);
+    thisTMB->SetCfeb4RxPosNeg(posneg);
+  }
+  if (thisTMB->HasGroupedME11ABCFEBRxValues() == 0){
+    thisTMB->SetCfeb5RxPosNeg(posneg);
+    thisTMB->SetCfeb6RxPosNeg(posneg);
+  }
+  if (thisTMB->GetHardwareVersion() == 1){
     thisTMB->SetCfeb0123RxPosNeg(posneg);
     thisTMB->SetCfeb456RxPosNeg(posneg);
   }
@@ -699,27 +703,38 @@ void ChamberUtilities::SetCfebRxPosNeg(int posneg) {
 }
 
 void ChamberUtilities::SetCfebRxClockDelay(int delay) {
-  thisTMB->SetCfeb0RxClockDelay(delay); 		// Set delay in TMB object
-  thisTMB->WriteRegister(phaser_cfeb0_rxd_adr);	// Write delay to hardware
-  thisTMB->FirePhaser(phaser_cfeb0_rxd_adr);		// Load delay
+  if (thisTMB->HasGroupedME11ABCFEBRxValues() <= 0){
+    thisTMB->SetCfeb0RxClockDelay(delay); 		// Set delay in TMB object
+    thisTMB->WriteRegister(phaser_cfeb0_rxd_adr);	// Write delay to hardware
+    thisTMB->FirePhaser(phaser_cfeb0_rxd_adr);		// Load delay
+    //
+    thisTMB->SetCfeb1RxClockDelay(delay);
+    thisTMB->WriteRegister(phaser_cfeb1_rxd_adr);
+    thisTMB->FirePhaser(phaser_cfeb1_rxd_adr);
+    //
+    thisTMB->SetCfeb2RxClockDelay(delay);
+    thisTMB->WriteRegister(phaser_cfeb2_rxd_adr);
+    thisTMB->FirePhaser(phaser_cfeb2_rxd_adr);
+    //
+    thisTMB->SetCfeb3RxClockDelay(delay);
+    thisTMB->WriteRegister(phaser_cfeb3_rxd_adr);
+    thisTMB->FirePhaser(phaser_cfeb3_rxd_adr);
+    //
+    thisTMB->SetCfeb4RxClockDelay(delay);
+    thisTMB->WriteRegister(phaser_cfeb4_rxd_adr);
+    thisTMB->FirePhaser(phaser_cfeb4_rxd_adr);
+  }
+  if (thisTMB->HasGroupedME11ABCFEBRxValues() == 0){//ungrouped ME11
+    thisTMB->SetCfeb5RxClockDelay(delay);
+    thisTMB->WriteRegister(phaser_cfeb5_rxd_adr);
+    thisTMB->FirePhaser(phaser_cfeb5_rxd_adr);
+
+    thisTMB->SetCfeb6RxClockDelay(delay);
+    thisTMB->WriteRegister(phaser_cfeb6_rxd_adr);
+    thisTMB->FirePhaser(phaser_cfeb6_rxd_adr);
+  }
   //
-  thisTMB->SetCfeb1RxClockDelay(delay);
-  thisTMB->WriteRegister(phaser_cfeb1_rxd_adr);
-  thisTMB->FirePhaser(phaser_cfeb1_rxd_adr);
-  //
-  thisTMB->SetCfeb2RxClockDelay(delay);
-  thisTMB->WriteRegister(phaser_cfeb2_rxd_adr);
-  thisTMB->FirePhaser(phaser_cfeb2_rxd_adr);
-  //
-  thisTMB->SetCfeb3RxClockDelay(delay);
-  thisTMB->WriteRegister(phaser_cfeb3_rxd_adr);
-  thisTMB->FirePhaser(phaser_cfeb3_rxd_adr);
-  //
-  thisTMB->SetCfeb4RxClockDelay(delay);
-  thisTMB->WriteRegister(phaser_cfeb4_rxd_adr);
-  thisTMB->FirePhaser(phaser_cfeb4_rxd_adr);
-  //
-  if(thisTMB->GetHardwareVersion() == 2) {
+  if(thisTMB->HasGroupedME11ABCFEBRxValues() == 1) {//grouped ME11
     thisTMB->SetCfeb456RxClockDelay(delay);
     thisTMB->WriteRegister(phaser_cfeb456_rxd_adr);
     thisTMB->FirePhaser(phaser_cfeb456_rxd_adr);
@@ -877,7 +892,6 @@ inline void ChamberUtilities::CFEBTiming_PrintConfiguration(CFEBTiming_Configura
   (*MyOutput_) << std::setw(23) << "cfeb_rx_posneg: " << std::setw(4) << config.cfeb_rx_posneg << std::endl;
   (*MyOutput_) << std::setw(23) << "cfeb_rx_clock_delay: " << std::setw(4) << config.cfeb_rx_clock_delay << std::endl;
   (*MyOutput_) << std::setw(23) << "cfeb_clock_phase: " << std::setw(4) << config.cfeb_clock_phase << std::endl;
-  (*MyOutput_) << std::setw(23) << "groupME11AandB: " << std::setw(4) << config.groupME11AandB << std::endl;
 }
     //
 inline bool ChamberUtilities::CFEBTiming_CheckCLCT(int cfeb, unsigned int layer_mask, unsigned int pattern, unsigned int halfstrip) {
@@ -932,7 +946,7 @@ inline void ChamberUtilities::CFEBTiming_ReadConfiguration(CFEBTiming_Configurat
     config.tmb_l1a_delay = thisTMB->GetL1aDelay();
   }
   
-  if (config.groupME11AandB){
+  if (thisTMB->HasGroupedME11ABCFEBRxValues()==1){
     thisTMB->ReadRegister(phaser_cfeb0123_rxd_adr); // Get phaser information
     config.cfeb_rx_posneg = thisTMB->GetReadCfeb0123RxPosNeg();
     config.cfeb_rx_clock_delay = thisTMB->GetReadCfeb0123RxClockDelay();
@@ -1011,10 +1025,6 @@ inline bool ChamberUtilities::CFEBTiming_CheckConfiguration(const CFEBTiming_Con
   }
   if(read.cfeb_rx_clock_delay != orig.cfeb_rx_clock_delay) {
     (*MyOutput_) << std::setw(37) << "BAD cfeb_rx_clock_delay: EXPECTED: " << std::setw(4) << orig.cfeb_rx_clock_delay << " | READ: " << std::setw(4) << read.cfeb_rx_clock_delay << std::endl;
-    same = false;
-  }
-  if(is_me11_ && ( read.groupME11AandB != orig.groupME11AandB )) {
-    (*MyOutput_) << std::setw(37) << "BAD groupME11AandB: EXPECTED: " << std::setw(4) << orig.groupME11AandB << " | READ: " << std::setw(4) << read.groupME11AandB << std::endl;
     same = false;
   }
   return same;
@@ -1530,8 +1540,7 @@ void ChamberUtilities::Print_CFEB_Masks() {
 }
     //
 void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, int cfeb_num, unsigned int layers, unsigned int pattern, 
-							      int halfstrip, bool print_data, int cfeb_clock_phase,
-							      bool groupME11AandB) {
+							      int halfstrip, bool print_data, int cfeb_clock_phase) {
   
   std::time_t init_time=time(0);
   
@@ -1641,7 +1650,6 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
     config.cfeb_mask = 0x7f;
   else
     config.cfeb_mask = 0x1 << cfeb_num;
-  config.groupME11AandB = groupME11AandB;
   
   CFEBTiming_PrintConfiguration(config);
   
@@ -1666,59 +1674,65 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
       web_backup << "DCFEB " << cfeb << " clock phase = " << config.cfeb_clock_phase << std::endl;
     }
 
-    if (!groupME11AandB){
+    if (thisTMB->HasGroupedME11ABCFEBRxValues()<=0){
       thisTMB->ReadRegister(phaser_cfeb0_rxd_adr); // Get phaser information
       thisTMB->ReadRegister(phaser_cfeb1_rxd_adr);
       thisTMB->ReadRegister(phaser_cfeb2_rxd_adr);
       thisTMB->ReadRegister(phaser_cfeb3_rxd_adr);
       thisTMB->ReadRegister(phaser_cfeb4_rxd_adr);
-      thisTMB->ReadRegister(phaser_cfeb456_rxd_adr);
-      thisTMB->ReadRegister(phaser_cfeb0123_rxd_adr);
+      thisTMB->ReadRegister(phaser_cfeb5_rxd_adr);
+      thisTMB->ReadRegister(phaser_cfeb6_rxd_adr);
     } else {
       thisTMB->ReadRegister(phaser_cfeb456_rxd_adr);
       thisTMB->ReadRegister(phaser_cfeb0123_rxd_adr);
     }
     //
-    if (!groupME11AandB){
+    if (thisTMB->HasGroupedME11ABCFEBRxValues()<=0){
       initial_cfeb_phase[0] = thisTMB->GetReadCfeb0RxClockDelay();
       initial_cfeb_phase[1] = thisTMB->GetReadCfeb1RxClockDelay();
       initial_cfeb_phase[2] = thisTMB->GetReadCfeb2RxClockDelay();
       initial_cfeb_phase[3] = thisTMB->GetReadCfeb3RxClockDelay();
       initial_cfeb_phase[4] = thisTMB->GetReadCfeb4RxClockDelay();
-      initial_cfeb_phase[5] = thisTMB->GetReadCfeb456RxClockDelay();
-      initial_cfeb_phase[6] = thisTMB->GetReadCfeb0123RxClockDelay();
+      initial_cfeb_phase[5] = thisTMB->GetReadCfeb5RxClockDelay();
+      initial_cfeb_phase[6] = thisTMB->GetReadCfeb6RxClockDelay();
       //
       initial_cfeb_posneg[0] = thisTMB->GetReadCfeb0RxPosNeg();
       initial_cfeb_posneg[1] = thisTMB->GetReadCfeb1RxPosNeg();
       initial_cfeb_posneg[2] = thisTMB->GetReadCfeb2RxPosNeg();
       initial_cfeb_posneg[3] = thisTMB->GetReadCfeb3RxPosNeg();
       initial_cfeb_posneg[4] = thisTMB->GetReadCfeb4RxPosNeg();
-      initial_cfeb_posneg[5] = thisTMB->GetReadCfeb456RxPosNeg();
-      initial_cfeb_posneg[6] = thisTMB->GetReadCfeb0123RxPosNeg();
+      initial_cfeb_posneg[5] = thisTMB->GetReadCfeb5RxPosNeg();
+      initial_cfeb_posneg[6] = thisTMB->GetReadCfeb6RxPosNeg();
+
+      initial_cfeb_rxd_int_delay[0] = thisTMB->GetCFEB0RxdIntDelay();
+      initial_cfeb_rxd_int_delay[1] = thisTMB->GetCFEB1RxdIntDelay();
+      initial_cfeb_rxd_int_delay[2] = thisTMB->GetCFEB2RxdIntDelay();
+      initial_cfeb_rxd_int_delay[3] = thisTMB->GetCFEB3RxdIntDelay();
+      initial_cfeb_rxd_int_delay[4] = thisTMB->GetCFEB4RxdIntDelay();
+      initial_cfeb_rxd_int_delay[5] = thisTMB->GetCFEB5RxdIntDelay();
+      initial_cfeb_rxd_int_delay[6] = thisTMB->GetCFEB6RxdIntDelay();
     } else {
       int initialPhase0123 = thisTMB->GetReadCfeb0123RxClockDelay();
       int initialPhase456 = thisTMB->GetReadCfeb456RxClockDelay();
 
       int initialPosneg0123 = thisTMB->GetReadCfeb0123RxPosNeg();
       int initialPosneg456 = thisTMB->GetReadCfeb456RxPosNeg();
-
+      
+      int initialRxdInt0123 = thisTMB->GetReadCFEB0123RxdIntDelay();
+      int initialRxdInt456 = thisTMB->GetReadCFEB456RxdIntDelay();
+      
       for (int i=0;i<4;++i){
 	initial_cfeb_phase[i] = initialPhase0123;
 	initial_cfeb_posneg[i] = initialPosneg0123;
+	initial_cfeb_rxd_int_delay[i] = initialRxdInt0123;
       }
       for (int i=4;i<7;++i){
 	initial_cfeb_phase[i] = initialPhase456;
 	initial_cfeb_posneg[i] = initialPosneg456;
+	initial_cfeb_rxd_int_delay[i] = initialRxdInt456;
       }
     }
     //
-    initial_cfeb_rxd_int_delay[0] = thisTMB->GetCFEB0RxdIntDelay();
-    initial_cfeb_rxd_int_delay[1] = thisTMB->GetCFEB1RxdIntDelay();
-    initial_cfeb_rxd_int_delay[2] = thisTMB->GetCFEB2RxdIntDelay();
-    initial_cfeb_rxd_int_delay[3] = thisTMB->GetCFEB3RxdIntDelay();
-    initial_cfeb_rxd_int_delay[4] = thisTMB->GetCFEB4RxdIntDelay();
-    initial_cfeb_rxd_int_delay[5] = thisTMB->GetCFEB5RxdIntDelay();
-    initial_cfeb_rxd_int_delay[6] = thisTMB->GetCFEB6RxdIntDelay();
     //
     
   }
@@ -2328,40 +2342,57 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
   //
   if(is_me11_) {
     //
-    thisTMB->SetCfeb0RxClockDelay(initial_cfeb_phase[0]);
-    thisTMB->SetCfeb0RxPosNeg(initial_cfeb_posneg[0]);
-    thisTMB->WriteRegister(phaser_cfeb0_rxd_adr);
-    thisTMB->FirePhaser(phaser_cfeb0_rxd_adr);
-    //
-    thisTMB->SetCfeb1RxClockDelay(initial_cfeb_phase[1]);
-    thisTMB->SetCfeb1RxPosNeg(initial_cfeb_posneg[1]);
-    thisTMB->WriteRegister(phaser_cfeb1_rxd_adr);
-    thisTMB->FirePhaser(phaser_cfeb1_rxd_adr);
-    //
-    thisTMB->SetCfeb2RxClockDelay(initial_cfeb_phase[2]);
-    thisTMB->SetCfeb2RxPosNeg(initial_cfeb_posneg[2]);
-    thisTMB->WriteRegister(phaser_cfeb2_rxd_adr);
-    thisTMB->FirePhaser(phaser_cfeb2_rxd_adr);
-    //
-    thisTMB->SetCfeb3RxClockDelay(initial_cfeb_phase[3]);
-    thisTMB->SetCfeb3RxPosNeg(initial_cfeb_posneg[3]);
-    thisTMB->WriteRegister(phaser_cfeb3_rxd_adr);
-    thisTMB->FirePhaser(phaser_cfeb3_rxd_adr);
-    //
-    thisTMB->SetCfeb4RxClockDelay(initial_cfeb_phase[4]);
-    thisTMB->SetCfeb4RxPosNeg(initial_cfeb_posneg[4]);
-    thisTMB->WriteRegister(phaser_cfeb4_rxd_adr);
-    thisTMB->FirePhaser(phaser_cfeb4_rxd_adr);
-    //
-    thisTMB->SetCfeb456RxClockDelay(initial_cfeb_phase[groupME11AandB ? 4 : 5]);
-    thisTMB->SetCfeb456RxPosNeg(initial_cfeb_posneg[groupME11AandB ? 4 : 5]);
-    thisTMB->WriteRegister(phaser_cfeb456_rxd_adr);
-    thisTMB->FirePhaser(phaser_cfeb456_rxd_adr);
-    //
-    thisTMB->SetCfeb0123RxClockDelay(initial_cfeb_phase[groupME11AandB ? 0 : 6]);
-    thisTMB->SetCfeb0123RxPosNeg(initial_cfeb_posneg[groupME11AandB ? 0 : 6]);
-    thisTMB->WriteRegister(phaser_cfeb0123_rxd_adr);
-    thisTMB->FirePhaser(phaser_cfeb0123_rxd_adr);
+    if (thisTMB->HasGroupedME11ABCFEBRxValues() <=0){
+      thisTMB->SetCfeb0RxClockDelay(initial_cfeb_phase[0]);
+      thisTMB->SetCfeb0RxPosNeg(initial_cfeb_posneg[0]);
+      thisTMB->WriteRegister(phaser_cfeb0_rxd_adr);
+      thisTMB->FirePhaser(phaser_cfeb0_rxd_adr);
+      //
+      thisTMB->SetCfeb1RxClockDelay(initial_cfeb_phase[1]);
+      thisTMB->SetCfeb1RxPosNeg(initial_cfeb_posneg[1]);
+      thisTMB->WriteRegister(phaser_cfeb1_rxd_adr);
+      thisTMB->FirePhaser(phaser_cfeb1_rxd_adr);
+      //
+      thisTMB->SetCfeb2RxClockDelay(initial_cfeb_phase[2]);
+      thisTMB->SetCfeb2RxPosNeg(initial_cfeb_posneg[2]);
+      thisTMB->WriteRegister(phaser_cfeb2_rxd_adr);
+      thisTMB->FirePhaser(phaser_cfeb2_rxd_adr);
+      //
+      thisTMB->SetCfeb3RxClockDelay(initial_cfeb_phase[3]);
+      thisTMB->SetCfeb3RxPosNeg(initial_cfeb_posneg[3]);
+      thisTMB->WriteRegister(phaser_cfeb3_rxd_adr);
+      thisTMB->FirePhaser(phaser_cfeb3_rxd_adr);
+      //
+      thisTMB->SetCfeb4RxClockDelay(initial_cfeb_phase[4]);
+      thisTMB->SetCfeb4RxPosNeg(initial_cfeb_posneg[4]);
+      thisTMB->WriteRegister(phaser_cfeb4_rxd_adr);
+      thisTMB->FirePhaser(phaser_cfeb4_rxd_adr);
+    }
+    if (thisTMB->HasGroupedME11ABCFEBRxValues() == 0){//ungrouped ME11
+      //
+      thisTMB->SetCfeb5RxClockDelay(initial_cfeb_phase[5]);
+      thisTMB->SetCfeb5RxPosNeg(initial_cfeb_posneg[5]);
+      thisTMB->WriteRegister(phaser_cfeb5_rxd_adr);
+      thisTMB->FirePhaser(phaser_cfeb5_rxd_adr);
+      //
+      thisTMB->SetCfeb6RxClockDelay(initial_cfeb_phase[6]);
+      thisTMB->SetCfeb6RxPosNeg(initial_cfeb_posneg[6]);
+      thisTMB->WriteRegister(phaser_cfeb6_rxd_adr);
+      thisTMB->FirePhaser(phaser_cfeb6_rxd_adr);
+
+    }
+    if (thisTMB->HasGroupedME11ABCFEBRxValues() == 1){//grouped ME11
+      //
+      thisTMB->SetCfeb456RxClockDelay(initial_cfeb_phase[4]);
+      thisTMB->SetCfeb456RxPosNeg(initial_cfeb_posneg[4]);
+      thisTMB->WriteRegister(phaser_cfeb456_rxd_adr);
+      thisTMB->FirePhaser(phaser_cfeb456_rxd_adr);
+      //
+      thisTMB->SetCfeb0123RxClockDelay(initial_cfeb_phase[0]);
+      thisTMB->SetCfeb0123RxPosNeg(initial_cfeb_posneg[0]);
+      thisTMB->WriteRegister(phaser_cfeb0123_rxd_adr);
+      thisTMB->FirePhaser(phaser_cfeb0123_rxd_adr);
+    }
 
     //
     if(!is_cfeb_clock_phase_inherited) {

--- a/emuDCS/PeripheralApps/src/common/EmuEndcapConfigWrapper.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuEndcapConfigWrapper.cc
@@ -494,11 +494,23 @@ throw (emu::exception::ConfigurationException)
   if (conf->has("ALCT_RX_CLOCK_DELAY"))    tmb_->SetAlctRXclockDelay( getInt(conf, "ALCT_RX_CLOCK_DELAY"));
   if (conf->has("DMB_TX_DELAY"))           tmb_->SetDmbTxDelay( getInt(conf, "DMB_TX_DELAY"));
   if (conf->has("RAT_TMB_DELAY"))          tmb_->SetRatTmbDelay( getInt(conf, "RAT_TMB_DELAY"));
-  if (conf->has("CFEB0DELAY"))             tmb_->SetCFEB0delay( getInt(conf, "CFEB0DELAY"));
-  if (conf->has("CFEB1DELAY"))             tmb_->SetCFEB1delay( getInt(conf, "CFEB1DELAY"));
-  if (conf->has("CFEB2DELAY"))             tmb_->SetCFEB2delay( getInt(conf, "CFEB2DELAY"));
-  if (conf->has("CFEB3DELAY"))             tmb_->SetCFEB3delay( getInt(conf, "CFEB3DELAY"));
-  if (conf->has("CFEB4DELAY"))             tmb_->SetCFEB4delay( getInt(conf, "CFEB4DELAY"));
+
+  if (not tmb_->ExpectedTmbFirmwareConfigIsSet()) throw "TMB Expected Firmware Is Not Set";
+  if (tmb_->HasGroupedME11ABCFEBRxValues() <= 0){
+    if (conf->has("CFEB0DELAY"))             tmb_->SetCFEB0delay( getInt(conf, "CFEB0DELAY"));
+    if (conf->has("CFEB1DELAY"))             tmb_->SetCFEB1delay( getInt(conf, "CFEB1DELAY"));
+    if (conf->has("CFEB2DELAY"))             tmb_->SetCFEB2delay( getInt(conf, "CFEB2DELAY"));
+    if (conf->has("CFEB3DELAY"))             tmb_->SetCFEB3delay( getInt(conf, "CFEB3DELAY"));
+    if (conf->has("CFEB4DELAY"))             tmb_->SetCFEB4delay( getInt(conf, "CFEB4DELAY"));
+    if (tmb_->GetHardwareVersion() ==2){
+      if (conf->has("CFEB5DELAY"))             tmb_->SetCFEB3delay( getInt(conf, "CFEB5DELAY"));
+      if (conf->has("CFEB6DELAY"))             tmb_->SetCFEB4delay( getInt(conf, "CFEB6DELAY"));      
+    }
+  } else {
+    if (conf->has("CFEB0123DELAY"))             tmb_->SetCFEB3delay( getInt(conf, "CFEB0123DELAY"));
+    if (conf->has("CFEB456DELAY"))             tmb_->SetCFEB4delay( getInt(conf, "CFEB456DELAY"));
+  }
+
   if (conf->has("RPC0_RAT_DELAY"))         tmb_->SetRpc0RatDelay( getInt(conf, "RPC0_RAT_DELAY"));
   if (conf->has("RPC1_RAT_DELAY"))         tmb_->SetRpc1RatDelay( getInt(conf, "RPC1_RAT_DELAY"));
   if (conf->has("ADJACENT_CFEB_DISTANCE")) tmb_->SetAdjacentCfebDistance( getInt(conf, "ADJACENT_CFEB_DISTANCE"));
@@ -514,11 +526,20 @@ throw (emu::exception::ConfigurationException)
   if (conf->has("TMB_FIFO_NO_RAW_HITS"))   tmb_->SetFifoNoRawHits( getInt(conf, "TMB_FIFO_NO_RAW_HITS"));
 
   if (conf->has("ALCT_TX_POSNEG"))         tmb_->SetAlctTxPosNeg( getInt(conf, "ALCT_TX_POSNEG"));
-  if (conf->has("CFEB0POSNEG"))            tmb_->SetCfeb0RxPosNeg( getInt(conf, "CFEB0POSNEG"));
-  if (conf->has("CFEB1POSNEG"))            tmb_->SetCfeb1RxPosNeg( getInt(conf, "CFEB1POSNEG"));
-  if (conf->has("CFEB2POSNEG"))            tmb_->SetCfeb2RxPosNeg( getInt(conf, "CFEB2POSNEG"));
-  if (conf->has("CFEB3POSNEG"))            tmb_->SetCfeb3RxPosNeg( getInt(conf, "CFEB3POSNEG"));
-  if (conf->has("CFEB4POSNEG"))            tmb_->SetCfeb4RxPosNeg( getInt(conf, "CFEB4POSNEG"));
+  if (tmb_->HasGroupedME11ABCFEBRxValues() <= 0){
+    if (conf->has("CFEB0POSNEG"))            tmb_->SetCfeb0RxPosNeg( getInt(conf, "CFEB0POSNEG"));
+    if (conf->has("CFEB1POSNEG"))            tmb_->SetCfeb1RxPosNeg( getInt(conf, "CFEB1POSNEG"));
+    if (conf->has("CFEB2POSNEG"))            tmb_->SetCfeb2RxPosNeg( getInt(conf, "CFEB2POSNEG"));
+    if (conf->has("CFEB3POSNEG"))            tmb_->SetCfeb3RxPosNeg( getInt(conf, "CFEB3POSNEG"));
+    if (conf->has("CFEB4POSNEG"))            tmb_->SetCfeb4RxPosNeg( getInt(conf, "CFEB4POSNEG"));
+    if (tmb_->GetHardwareVersion() ==2){
+      if (conf->has("CFEB5POSNEG"))             tmb_->SetCfeb5RxPosNeg( getInt(conf, "CFEB5POSNEG"));
+      if (conf->has("CFEB6POSNEG"))             tmb_->SetCfeb6RxPosNeg( getInt(conf, "CFEB6POSNEG"));
+    }
+  } else {
+    if (conf->has("CFEB0123POSNEG"))             tmb_->SetCfeb5RxPosNeg( getInt(conf, "CFEB0123POSNEG"));
+    if (conf->has("CFEB456POSNEG"))             tmb_->SetCfeb6RxPosNeg( getInt(conf, "CFEB456POSNEG"));
+  }
   if (conf->has("MPC_SEL_TTC_BX0"))        tmb_->SetSelectMpcTtcBx0( getInt(conf, "MPC_SEL_TTC_BX0"));
   if (conf->has("ALCT_TOF_DELAY"))         tmb_->SetAlctTOFDelay( getInt(conf, "ALCT_TOF_DELAY"));
   if (conf->has("TMB_TO_ALCT_DATA_DELAY")) tmb_->SetALCTTxDataDelay( getInt(conf, "TMB_TO_ALCT_DATA_DELAY"));
@@ -529,11 +550,20 @@ throw (emu::exception::ConfigurationException)
   if (conf->has("CFEB3_TOF_DELAY"))        tmb_->SetCfeb3TOFDelay( getInt(conf, "CFEB3_TOF_DELAY"));
   if (conf->has("CFEB4_TOF_DELAY"))        tmb_->SetCfeb4TOFDelay( getInt(conf, "CFEB4_TOF_DELAY"));
   if (conf->has("CFEB_BADBITS_BLOCK"))     tmb_->SetCFEBBadBitsBlock( getInt(conf, "CFEB_BADBITS_BLOCK"));
-  if (conf->has("CFEB0_RXD_INT_DELAY"))    tmb_->SetCFEB0RxdIntDelay( getInt(conf, "CFEB0_RXD_INT_DELAY"));
-  if (conf->has("CFEB1_RXD_INT_DELAY"))    tmb_->SetCFEB1RxdIntDelay( getInt(conf, "CFEB1_RXD_INT_DELAY"));
-  if (conf->has("CFEB2_RXD_INT_DELAY"))    tmb_->SetCFEB2RxdIntDelay( getInt(conf, "CFEB2_RXD_INT_DELAY"));
-  if (conf->has("CFEB3_RXD_INT_DELAY"))    tmb_->SetCFEB3RxdIntDelay( getInt(conf, "CFEB3_RXD_INT_DELAY"));
-  if (conf->has("CFEB4_RXD_INT_DELAY"))    tmb_->SetCFEB4RxdIntDelay( getInt(conf, "CFEB4_RXD_INT_DELAY"));
+  if (tmb_->HasGroupedME11ABCFEBRxValues() <= 0){
+    if (conf->has("CFEB0_RXD_INT_DELAY"))    tmb_->SetCFEB0RxdIntDelay( getInt(conf, "CFEB0_RXD_INT_DELAY"));
+    if (conf->has("CFEB1_RXD_INT_DELAY"))    tmb_->SetCFEB1RxdIntDelay( getInt(conf, "CFEB1_RXD_INT_DELAY"));
+    if (conf->has("CFEB2_RXD_INT_DELAY"))    tmb_->SetCFEB2RxdIntDelay( getInt(conf, "CFEB2_RXD_INT_DELAY"));
+    if (conf->has("CFEB3_RXD_INT_DELAY"))    tmb_->SetCFEB3RxdIntDelay( getInt(conf, "CFEB3_RXD_INT_DELAY"));
+    if (conf->has("CFEB4_RXD_INT_DELAY"))    tmb_->SetCFEB4RxdIntDelay( getInt(conf, "CFEB4_RXD_INT_DELAY"));
+    if (tmb_->GetHardwareVersion() ==2){
+      if (conf->has("CFEB5_RXD_INT_DELAY"))    tmb_->SetCFEB3RxdIntDelay( getInt(conf, "CFEB5_RXD_INT_DELAY"));
+      if (conf->has("CFEB6_RXD_INT_DELAY"))    tmb_->SetCFEB4RxdIntDelay( getInt(conf, "CFEB6_RXD_INT_DELAY"));
+    }
+  } else {
+    if (conf->has("CFEB0123_RXD_INT_DELAY"))    tmb_->SetCFEB3RxdIntDelay( getInt(conf, "CFEB0123_RXD_INT_DELAY"));
+    if (conf->has("CFEB456_RXD_INT_DELAY"))    tmb_->SetCFEB4RxdIntDelay( getInt(conf, "CFEB456_RXD_INT_DELAY"));
+  }
   if (conf->has("CFEB_BADBITS_READOUT"))   tmb_->SetCFEBBadBitsReadout( getInt(conf, "CFEB_BADBITS_READOUT"));
   if (conf->has("L1A_PRIORITY_ENABLE"))    tmb_->SetL1APriorityEnable( getInt(conf, "L1A_PRIORITY_ENABLE"));
   if (conf->has("MINISCOPE_ENABLE"))       tmb_->SetMiniscopeEnable( getInt(conf, "MINISCOPE_ENABLE"));

--- a/emuDCS/PeripheralApps/src/common/EmuPCrateConfigTStore.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPCrateConfigTStore.cc
@@ -2001,6 +2001,10 @@ void EmuPCrateConfigTStore::copyTMBToTable(xdata::Table &newRows, TMB * TStore_t
     std::string CFEB2DELAY("CFEB2DELAY");
     std::string CFEB3DELAY("CFEB3DELAY");
     std::string CFEB4DELAY("CFEB4DELAY");
+    std::string CFEB5DELAY("CFEB5DELAY");
+    std::string CFEB6DELAY("CFEB6DELAY");
+    std::string CFEB0123DELAY("CFEB0123DELAY");
+    std::string CFEB456DELAY("CFEB456DELAY");
     std::string CFEB_ENABLE_SOURCE("CFEB_ENABLE_SOURCE");
     std::string CLCT_BLANKING("CLCT_BLANKING");
     std::string CLCT_BX0_DELAY("CLCT_BX0_DELAY");
@@ -2090,6 +2094,10 @@ void EmuPCrateConfigTStore::copyTMBToTable(xdata::Table &newRows, TMB * TStore_t
     std::string CFEB2POSNEG("CFEB2POSNEG");
     std::string CFEB3POSNEG("CFEB3POSNEG");
     std::string CFEB4POSNEG("CFEB4POSNEG");
+    std::string CFEB5POSNEG("CFEB5POSNEG");
+    std::string CFEB6POSNEG("CFEB6POSNEG");
+    std::string CFEB0123POSNEG("CFEB0123POSNEG");
+    std::string CFEB456POSNEG("CFEB456POSNEG");
     std::string MPC_SEL_TTC_BX0("MPC_SEL_TTC_BX0");
     std::string ALCT_TOF_DELAY("ALCT_TOF_DELAY");
     std::string TMB_TO_ALCT_DATA_DELAY("TMB_TO_ALCT_DATA_DELAY");
@@ -2105,6 +2113,10 @@ void EmuPCrateConfigTStore::copyTMBToTable(xdata::Table &newRows, TMB * TStore_t
     std::string CFEB2_RXD_INT_DELAY("CFEB2_RXD_INT_DELAY");
     std::string CFEB3_RXD_INT_DELAY("CFEB3_RXD_INT_DELAY");
     std::string CFEB4_RXD_INT_DELAY("CFEB4_RXD_INT_DELAY");
+    std::string CFEB5_RXD_INT_DELAY("CFEB5_RXD_INT_DELAY");
+    std::string CFEB6_RXD_INT_DELAY("CFEB6_RXD_INT_DELAY");
+    std::string CFEB0123_RXD_INT_DELAY("CFEB0123_RXD_INT_DELAY");
+    std::string CFEB456_RXD_INT_DELAY("CFEB456_RXD_INT_DELAY");
     std::string CFEB_BADBITS_READOUT("CFEB_BADBITS_READOUT");
     std::string L1A_PRIORITY_ENABLE("L1A_PRIORITY_ENABLE");
     std::string MINISCOPE_ENABLE("MINISCOPE_ENABLE");
@@ -2123,11 +2135,20 @@ void EmuPCrateConfigTStore::copyTMBToTable(xdata::Table &newRows, TMB * TStore_t
     xdata::UnsignedShort  _alct_tx_clock_delay         = TStore_thisTMB->GetALCTtxPhase();
     xdata::UnsignedShort  _alct_posneg		            = TStore_thisTMB->GetAlctPosNeg();
     xdata::UnsignedShort  _all_cfeb_active             = TStore_thisTMB->GetEnableAllCfebsActive();
-    xdata::UnsignedShort  _cfeb0delay                  = TStore_thisTMB->GetCFEB0delay();
-    xdata::UnsignedShort  _cfeb1delay                  = TStore_thisTMB->GetCFEB1delay();
-    xdata::UnsignedShort  _cfeb2delay                  = TStore_thisTMB->GetCFEB2delay();
-    xdata::UnsignedShort  _cfeb3delay                  = TStore_thisTMB->GetCFEB3delay();
-    xdata::UnsignedShort  _cfeb4delay                  = TStore_thisTMB->GetCFEB4delay();
+    bool use255 = TStore_thisTMB->HasGroupedME11ABCFEBRxValues() == 1;//true for ME11 OTMB with grouped CFEB RX delays
+    xdata::UnsignedShort  _cfeb0delay                  = use255 ? 255 : TStore_thisTMB->GetCFEB0delay();
+    xdata::UnsignedShort  _cfeb1delay                  = use255 ? 255 : TStore_thisTMB->GetCFEB1delay();
+    xdata::UnsignedShort  _cfeb2delay                  = use255 ? 255 : TStore_thisTMB->GetCFEB2delay();
+    xdata::UnsignedShort  _cfeb3delay                  = use255 ? 255 : TStore_thisTMB->GetCFEB3delay();
+    xdata::UnsignedShort  _cfeb4delay                  = use255 ? 255 : TStore_thisTMB->GetCFEB4delay();
+    use255 = TStore_thisTMB->HasGroupedME11ABCFEBRxValues() != 1;//for ME11 OTMB with grouped CFEB RX delays
+    xdata::UnsignedShort  _cfeb0123delay               = use255 ? 255 : TStore_thisTMB->GetCFEB0123delay();
+    xdata::UnsignedShort  _cfeb456delay                = use255 ? 255 : TStore_thisTMB->GetCFEB456delay();
+    use255 = TStore_thisTMB->HasGroupedME11ABCFEBRxValues() != 0;//old OTMB FW version with all 7 CFEB RX delays
+    xdata::UnsignedShort  _cfeb5delay                  = use255 ? 255 : TStore_thisTMB->GetCFEB5delay();
+    xdata::UnsignedShort  _cfeb6delay                  = use255 ? 255 : TStore_thisTMB->GetCFEB6delay();
+
+
     xdata::UnsignedShort  _cfeb_enable_source          = TStore_thisTMB->GetCfebEnableSource_orig();
     xdata::UnsignedShort  _clct_blanking               = TStore_thisTMB->GetClctBlanking();
     xdata::UnsignedShort  _clct_bx0_delay              = TStore_thisTMB->GetClctBx0Delay();
@@ -2222,11 +2243,20 @@ void EmuPCrateConfigTStore::copyTMBToTable(xdata::Table &newRows, TMB * TStore_t
     xdata::UnsignedShort  _write_buffer_autoclear        = TStore_thisTMB->GetWriteBufferAutoclear();
     xdata::UnsignedShort  _write_buffer_continous_enable = TStore_thisTMB->GetClctWriteContinuousEnable();
     xdata::UnsignedShort  _alct_tx_posneg                =  TStore_thisTMB->GetAlctTxPosNeg();
-    xdata::UnsignedShort  _cfeb0posneg                   = TStore_thisTMB->GetCfeb0RxPosNeg();
-    xdata::UnsignedShort  _cfeb1posneg                   = TStore_thisTMB->GetCfeb1RxPosNeg();
-    xdata::UnsignedShort  _cfeb2posneg                   = TStore_thisTMB->GetCfeb2RxPosNeg();
-    xdata::UnsignedShort  _cfeb3posneg                   = TStore_thisTMB->GetCfeb3RxPosNeg();
-    xdata::UnsignedShort  _cfeb4posneg                   = TStore_thisTMB->GetCfeb4RxPosNeg();
+    use255 = TStore_thisTMB->HasGroupedME11ABCFEBRxValues() == 1;//true for ME11 OTMB with grouped CFEB RX delays
+    xdata::UnsignedShort  _cfeb0posneg                   = use255 ? 255 : TStore_thisTMB->GetCfeb0RxPosNeg();
+    xdata::UnsignedShort  _cfeb1posneg                   = use255 ? 255 : TStore_thisTMB->GetCfeb1RxPosNeg();
+    xdata::UnsignedShort  _cfeb2posneg                   = use255 ? 255 : TStore_thisTMB->GetCfeb2RxPosNeg();
+    xdata::UnsignedShort  _cfeb3posneg                   = use255 ? 255 : TStore_thisTMB->GetCfeb3RxPosNeg();
+    xdata::UnsignedShort  _cfeb4posneg                   = use255 ? 255 : TStore_thisTMB->GetCfeb4RxPosNeg();
+    use255 = TStore_thisTMB->HasGroupedME11ABCFEBRxValues() != 1;//for ME11 OTMB with grouped CFEB RX delays  
+    xdata::UnsignedShort  _cfeb0123posneg                   = use255 ? 255 : TStore_thisTMB->GetCfeb0123RxPosNeg();
+    xdata::UnsignedShort  _cfeb456posneg                   = use255 ? 255 : TStore_thisTMB->GetCfeb456RxPosNeg();
+    use255 = TStore_thisTMB->HasGroupedME11ABCFEBRxValues() != 0;//old OTMB FW version with all 7 CFEB RX delays
+    xdata::UnsignedShort  _cfeb5posneg                   = use255 ? 255 : TStore_thisTMB->GetCfeb5RxPosNeg();
+    xdata::UnsignedShort  _cfeb6posneg                   = use255 ? 255 : TStore_thisTMB->GetCfeb6RxPosNeg();
+
+
     xdata::UnsignedShort  _mpc_sel_ttc_bx0               = TStore_thisTMB->GetSelectMpcTtcBx0();
     xdata::UnsignedShort  _alct_tof_delay                = TStore_thisTMB->GetAlctTOFDelay();
     xdata::UnsignedShort  _tmb_to_alct_data_delay        = TStore_thisTMB->GetALCTTxDataDelay();
@@ -2237,11 +2267,19 @@ void EmuPCrateConfigTStore::copyTMBToTable(xdata::Table &newRows, TMB * TStore_t
     xdata::UnsignedShort  _cfeb3_tof_delay               = TStore_thisTMB->GetCfeb3TOFDelay();
     xdata::UnsignedShort  _cfeb4_tof_delay               = TStore_thisTMB->GetCfeb4TOFDelay();
     xdata::UnsignedShort  _cfeb_badbits_block            = TStore_thisTMB->GetCFEBBadBitsBlock();
-    xdata::UnsignedShort  _cfeb0_rxd_int_delay           = TStore_thisTMB->GetCFEB0RxdIntDelay();
-    xdata::UnsignedShort  _cfeb1_rxd_int_delay           = TStore_thisTMB->GetCFEB1RxdIntDelay();
-    xdata::UnsignedShort  _cfeb2_rxd_int_delay           = TStore_thisTMB->GetCFEB2RxdIntDelay();
-    xdata::UnsignedShort  _cfeb3_rxd_int_delay           = TStore_thisTMB->GetCFEB3RxdIntDelay();
-    xdata::UnsignedShort  _cfeb4_rxd_int_delay           = TStore_thisTMB->GetCFEB4RxdIntDelay();
+    use255 = TStore_thisTMB->HasGroupedME11ABCFEBRxValues() == 1;//true for ME11 OTMB with grouped CFEB RX delays 
+    xdata::UnsignedShort  _cfeb0_rxd_int_delay           = use255 ? 255 : TStore_thisTMB->GetCFEB0RxdIntDelay();
+    xdata::UnsignedShort  _cfeb1_rxd_int_delay           = use255 ? 255 : TStore_thisTMB->GetCFEB1RxdIntDelay();
+    xdata::UnsignedShort  _cfeb2_rxd_int_delay           = use255 ? 255 : TStore_thisTMB->GetCFEB2RxdIntDelay();
+    xdata::UnsignedShort  _cfeb3_rxd_int_delay           = use255 ? 255 : TStore_thisTMB->GetCFEB3RxdIntDelay();
+    xdata::UnsignedShort  _cfeb4_rxd_int_delay           = use255 ? 255 : TStore_thisTMB->GetCFEB4RxdIntDelay();
+    use255 = TStore_thisTMB->HasGroupedME11ABCFEBRxValues() != 1;//for ME11 OTMB with grouped CFEB RX delays    
+    xdata::UnsignedShort  _cfeb0123_rxd_int_delay        = use255 ? 255 : TStore_thisTMB->GetCFEB0123RxdIntDelay();
+    xdata::UnsignedShort  _cfeb456_rxd_int_delay         = use255 ? 255 : TStore_thisTMB->GetCFEB456RxdIntDelay();
+    use255 = TStore_thisTMB->HasGroupedME11ABCFEBRxValues() != 0;//old OTMB FW version with all 7 CFEB RX delays
+    xdata::UnsignedShort  _cfeb5_rxd_int_delay           = use255 ? 255 : TStore_thisTMB->GetCFEB5RxdIntDelay();
+    xdata::UnsignedShort  _cfeb6_rxd_int_delay           = use255 ? 255 : TStore_thisTMB->GetCFEB6RxdIntDelay();
+
     xdata::UnsignedShort  _cfeb_badbits_readout          = TStore_thisTMB->GetCFEBBadBitsReadout();
     xdata::UnsignedShort  _l1a_priority_enable           = TStore_thisTMB->GetL1APriorityEnable();
     xdata::UnsignedShort  _miniscope_enable              = TStore_thisTMB->GetMiniscopeEnable();
@@ -2266,6 +2304,10 @@ void EmuPCrateConfigTStore::copyTMBToTable(xdata::Table &newRows, TMB * TStore_t
     newRows.setValueAt(rowId, CFEB2DELAY,                    _cfeb2delay);
     newRows.setValueAt(rowId, CFEB3DELAY,                    _cfeb3delay);
     newRows.setValueAt(rowId, CFEB4DELAY,                    _cfeb4delay);
+    newRows.setValueAt(rowId, CFEB5DELAY,                    _cfeb5delay);
+    newRows.setValueAt(rowId, CFEB6DELAY,                    _cfeb6delay);
+    newRows.setValueAt(rowId, CFEB0123DELAY,                 _cfeb0123delay);
+    newRows.setValueAt(rowId, CFEB456DELAY,                  _cfeb456delay);
     newRows.setValueAt(rowId, CFEB_ENABLE_SOURCE,            _cfeb_enable_source);
     newRows.setValueAt(rowId, CLCT_BLANKING,                 _clct_blanking);
     newRows.setValueAt(rowId, CLCT_BX0_DELAY,                _clct_bx0_delay);
@@ -2355,6 +2397,10 @@ void EmuPCrateConfigTStore::copyTMBToTable(xdata::Table &newRows, TMB * TStore_t
     newRows.setValueAt(rowId, CFEB2POSNEG,                   _cfeb2posneg);
     newRows.setValueAt(rowId, CFEB3POSNEG,                   _cfeb3posneg);
     newRows.setValueAt(rowId, CFEB4POSNEG,                   _cfeb4posneg);
+    newRows.setValueAt(rowId, CFEB5POSNEG,                   _cfeb5posneg);
+    newRows.setValueAt(rowId, CFEB6POSNEG,                   _cfeb6posneg);
+    newRows.setValueAt(rowId, CFEB0123POSNEG,                _cfeb0123posneg);
+    newRows.setValueAt(rowId, CFEB456POSNEG,                 _cfeb456posneg);
     newRows.setValueAt(rowId, MPC_SEL_TTC_BX0,               _mpc_sel_ttc_bx0);
     newRows.setValueAt(rowId, ALCT_TOF_DELAY,                _alct_tof_delay);
     newRows.setValueAt(rowId, TMB_TO_ALCT_DATA_DELAY,        _tmb_to_alct_data_delay);
@@ -2370,6 +2416,10 @@ void EmuPCrateConfigTStore::copyTMBToTable(xdata::Table &newRows, TMB * TStore_t
     newRows.setValueAt(rowId, CFEB2_RXD_INT_DELAY,           _cfeb2_rxd_int_delay);
     newRows.setValueAt(rowId, CFEB3_RXD_INT_DELAY,           _cfeb3_rxd_int_delay);
     newRows.setValueAt(rowId, CFEB4_RXD_INT_DELAY,           _cfeb4_rxd_int_delay);
+    newRows.setValueAt(rowId, CFEB5_RXD_INT_DELAY,           _cfeb5_rxd_int_delay);
+    newRows.setValueAt(rowId, CFEB6_RXD_INT_DELAY,           _cfeb6_rxd_int_delay);
+    newRows.setValueAt(rowId, CFEB0123_RXD_INT_DELAY,        _cfeb0123_rxd_int_delay);
+    newRows.setValueAt(rowId, CFEB456_RXD_INT_DELAY,         _cfeb456_rxd_int_delay);
     newRows.setValueAt(rowId, CFEB_BADBITS_READOUT,          _cfeb_badbits_readout);
     newRows.setValueAt(rowId, L1A_PRIORITY_ENABLE,           _l1a_priority_enable);
     newRows.setValueAt(rowId, MINISCOPE_ENABLE,              _miniscope_enable);
@@ -3461,17 +3511,32 @@ void EmuPCrateConfigTStore::readTMB(
       }
     }
     int tmbHwVersion = 0;
+    int tmbFwYear    = 0;
+    int tmbFwMonth   = 0;
+    int tmbFwDay     = 0;
     for (std::vector<std::string>::iterator column = columns.begin(); column != columns.end(); ++column)
-      {
-	if (*column != "HARDWARE_VERSION"      ) continue;
+      {//I don't know the order of columns. So, look first for the things that have to be set first
+	if (*column != "HARDWARE_VERSION"      
+	    && *column != "TMB_FIRMWARE_MONTH"
+	    && *column != "TMB_FIRMWARE_DAY"
+	    && *column != "TMB_FIRMWARE_YEAR") continue;
 	value = results.getValueAt(rowIndex, *column);
+	int intValue = -1;
 	if (results.getColumnType(*column) == "int")
 	  {
 	    xdata::Integer * i = dynamic_cast<xdata::Integer *> (value);
-	    if(! i->isNaN()) tmbHwVersion=(int)*i;
+	    if(! i->isNaN()) intValue=(int)*i;
 	  }
+	if (*column == "HARDWARE_VERSION"             )  tmbHwVersion = intValue;
+	if (*column == "TMB_FIRMWARE_YEAR"            )  tmbFwYear    = intValue;
+	if (*column == "TMB_FIRMWARE_MONTH"           )  tmbFwMonth   = intValue;
+	if (*column == "TMB_FIRMWARE_DAY"             )  tmbFwDay     = intValue;
       }
     TMB * tmb_ = new TMB(theCrate, theChamber, slot, tmbHwVersion);
+    tmb_->SetExpectedTmbFirmwareYear(tmbFwYear);
+    tmb_->SetExpectedTmbFirmwareMonth(tmbFwMonth);
+    tmb_->SetExpectedTmbFirmwareDay(tmbFwDay);
+
     for (std::vector<std::string>::iterator column = columns.begin(); column != columns.end(); ++column)
     {
       value = results.getValueAt(rowIndex, *column);
@@ -3483,9 +3548,6 @@ void EmuPCrateConfigTStore::readTMB(
       }
       StrgValue = value->toString();
       
-      if (*column == "TMB_FIRMWARE_MONTH"           ) tmb_->SetExpectedTmbFirmwareMonth(IntValue);
-      if (*column == "TMB_FIRMWARE_DAY"             ) tmb_->SetExpectedTmbFirmwareDay(IntValue);
-      if (*column == "TMB_FIRMWARE_YEAR"            ) tmb_->SetExpectedTmbFirmwareYear(IntValue);
       if (*column == "TMB_FIRMWARE_VERSION"         ) tmb_->SetExpectedTmbFirmwareVersion(IntValue);
       if (*column == "TMB_FIRMWARE_REVCODE"         ) tmb_->SetExpectedTmbFirmwareRevcode(IntValue);
       if (*column == "TMB_FIRMWARE_TYPE"            ) tmb_->SetExpectedTmbFirmwareType(IntValue);
@@ -3593,11 +3655,23 @@ void EmuPCrateConfigTStore::readTMB(
       if (*column == "ALCT_RX_CLOCK_DELAY"          ) tmb_->SetAlctRXclockDelay(IntValue);
       if (*column == "DMB_TX_DELAY"                 ) tmb_->SetDmbTxDelay(IntValue);
       if (*column == "RAT_TMB_DELAY"                ) tmb_->SetRatTmbDelay(IntValue);
-      if (*column == "CFEB0DELAY"                   ) tmb_->SetCFEB0delay(IntValue);
-      if (*column == "CFEB1DELAY"                   ) tmb_->SetCFEB1delay(IntValue);
-      if (*column == "CFEB2DELAY"                   ) tmb_->SetCFEB2delay(IntValue);
-      if (*column == "CFEB3DELAY"                   ) tmb_->SetCFEB3delay(IntValue);
-      if (*column == "CFEB4DELAY"                   ) tmb_->SetCFEB4delay(IntValue);
+
+      if (not tmb_->ExpectedTmbFirmwareConfigIsSet()) throw "TMB Expected Firmware Is Not Set";
+      if (tmb_->HasGroupedME11ABCFEBRxValues() <= 0){
+	if (*column == "CFEB0DELAY"                   ) tmb_->SetCFEB0delay(IntValue);
+	if (*column == "CFEB1DELAY"                   ) tmb_->SetCFEB1delay(IntValue);
+	if (*column == "CFEB2DELAY"                   ) tmb_->SetCFEB2delay(IntValue);
+	if (*column == "CFEB3DELAY"                   ) tmb_->SetCFEB3delay(IntValue);
+	if (*column == "CFEB4DELAY"                   ) tmb_->SetCFEB4delay(IntValue);
+	if (tmb_->GetHardwareVersion() ==2){
+	  if (*column == "CFEB5DELAY"                   ) tmb_->SetCFEB5delay(IntValue);
+	  if (*column == "CFEB6DELAY"                   ) tmb_->SetCFEB6delay(IntValue);
+	}
+      }
+      if (tmb_->HasGroupedME11ABCFEBRxValues() == 1){
+	if (*column == "CFEB0123DELAY"                  ) tmb_->SetCFEB0123delay(IntValue);
+	if (*column == "CFEB456DELAY"                   ) tmb_->SetCFEB456delay(IntValue);
+      }
       if (*column == "RPC0_RAT_DELAY"               ) tmb_->SetRpc0RatDelay(IntValue);
       if (*column == "RPC1_RAT_DELAY"               ) tmb_->SetRpc1RatDelay(IntValue);
       if (*column == "ADJACENT_CFEB_DISTANCE"       ) tmb_->SetAdjacentCfebDistance(IntValue);
@@ -3613,11 +3687,21 @@ void EmuPCrateConfigTStore::readTMB(
       if (*column == "TMB_FIFO_NO_RAW_HITS"         ) tmb_->SetFifoNoRawHits(IntValue);
       
       if (*column == "ALCT_TX_POSNEG"        ) tmb_->SetAlctTxPosNeg(IntValue);
-      if (*column == "CFEB0POSNEG"           ) tmb_->SetCfeb0RxPosNeg(IntValue);
-      if (*column == "CFEB1POSNEG"           ) tmb_->SetCfeb1RxPosNeg(IntValue);
-      if (*column == "CFEB2POSNEG"           ) tmb_->SetCfeb2RxPosNeg(IntValue);
-      if (*column == "CFEB3POSNEG"           ) tmb_->SetCfeb3RxPosNeg(IntValue);
-      if (*column == "CFEB4POSNEG"           ) tmb_->SetCfeb4RxPosNeg(IntValue);
+      if (tmb_->HasGroupedME11ABCFEBRxValues() <= 0){
+	if (*column == "CFEB0POSNEG"           ) tmb_->SetCfeb0RxPosNeg(IntValue);
+	if (*column == "CFEB1POSNEG"           ) tmb_->SetCfeb1RxPosNeg(IntValue);
+	if (*column == "CFEB2POSNEG"           ) tmb_->SetCfeb2RxPosNeg(IntValue);
+	if (*column == "CFEB3POSNEG"           ) tmb_->SetCfeb3RxPosNeg(IntValue);
+	if (*column == "CFEB4POSNEG"           ) tmb_->SetCfeb4RxPosNeg(IntValue);
+	if (tmb_->GetHardwareVersion() ==2){
+	  if (*column == "CFEB5POSNEG"           ) tmb_->SetCfeb5RxPosNeg(IntValue);
+	  if (*column == "CFEB6POSNEG"           ) tmb_->SetCfeb6RxPosNeg(IntValue);
+	}
+      }
+      if (tmb_->HasGroupedME11ABCFEBRxValues() == 1){
+	if (*column == "CFEB0123POSNEG"           ) tmb_->SetCfeb0123RxPosNeg(IntValue);
+	if (*column == "CFEB456POSNEG"           ) tmb_->SetCfeb456RxPosNeg(IntValue);
+      }
       if (*column == "MPC_SEL_TTC_BX0"       ) tmb_->SetSelectMpcTtcBx0(IntValue);
       if (*column == "ALCT_TOF_DELAY"        ) tmb_->SetAlctTOFDelay(IntValue);
       if (*column == "TMB_TO_ALCT_DATA_DELAY") tmb_->SetALCTTxDataDelay(IntValue);
@@ -3628,11 +3712,21 @@ void EmuPCrateConfigTStore::readTMB(
       if (*column == "CFEB3_TOF_DELAY"       ) tmb_->SetCfeb3TOFDelay(IntValue);
       if (*column == "CFEB4_TOF_DELAY"       ) tmb_->SetCfeb4TOFDelay(IntValue);
       if (*column == "CFEB_BADBITS_BLOCK"    ) tmb_->SetCFEBBadBitsBlock(IntValue);
-      if (*column == "CFEB0_RXD_INT_DELAY"   ) tmb_->SetCFEB0RxdIntDelay(IntValue);
-      if (*column == "CFEB1_RXD_INT_DELAY"   ) tmb_->SetCFEB1RxdIntDelay(IntValue);
-      if (*column == "CFEB2_RXD_INT_DELAY"   ) tmb_->SetCFEB2RxdIntDelay(IntValue);
-      if (*column == "CFEB3_RXD_INT_DELAY"   ) tmb_->SetCFEB3RxdIntDelay(IntValue);
-      if (*column == "CFEB4_RXD_INT_DELAY"   ) tmb_->SetCFEB4RxdIntDelay(IntValue);
+      if (tmb_->HasGroupedME11ABCFEBRxValues() <= 0){
+	if (*column == "CFEB0_RXD_INT_DELAY"   ) tmb_->SetCFEB0RxdIntDelay(IntValue);
+	if (*column == "CFEB1_RXD_INT_DELAY"   ) tmb_->SetCFEB1RxdIntDelay(IntValue);
+	if (*column == "CFEB2_RXD_INT_DELAY"   ) tmb_->SetCFEB2RxdIntDelay(IntValue);
+	if (*column == "CFEB3_RXD_INT_DELAY"   ) tmb_->SetCFEB3RxdIntDelay(IntValue);
+	if (*column == "CFEB4_RXD_INT_DELAY"   ) tmb_->SetCFEB4RxdIntDelay(IntValue);
+	if (tmb_->GetHardwareVersion() ==2){
+	  if (*column == "CFEB5_RXD_INT_DELAY"   ) tmb_->SetCFEB5RxdIntDelay(IntValue);
+	  if (*column == "CFEB6_RXD_INT_DELAY"   ) tmb_->SetCFEB6RxdIntDelay(IntValue);
+	}
+      }
+      if (tmb_->HasGroupedME11ABCFEBRxValues() == 1){
+	if (*column == "CFEB0123_RXD_INT_DELAY"   ) tmb_->SetCFEB0123RxdIntDelay(IntValue);
+	if (*column == "CFEB456_RXD_INT_DELAY"   )  tmb_->SetCFEB456RxdIntDelay(IntValue);
+      }
       if (*column == "CFEB_BADBITS_READOUT"  ) tmb_->SetCFEBBadBitsReadout(IntValue);
       if (*column == "L1A_PRIORITY_ENABLE"   ) tmb_->SetL1APriorityEnable(IntValue);
       if (*column == "MINISCOPE_ENABLE"      ) tmb_->SetMiniscopeEnable(IntValue);

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
@@ -5104,9 +5104,6 @@ void EmuPeripheralCrateConfig::ChamberTests(xgi::Input * in, xgi::Output * out )
   *out << cgicc::td().set("ALIGN", "left") << "CFEB" << cgicc::td() << std::endl;
   *out << cgicc::td().set("ALIGN", "left") << "Pattern Type" << cgicc::td() << std::endl;
   *out << cgicc::td().set("ALIGN", "left") << "Half-Strip" << cgicc::td() << std::endl;
-  if (thisTMB->GetHardwareVersion()>=2){
-    *out << cgicc::td().set("ALIGN", "left") << "Group ME11 A and B" << cgicc::td() << std::endl;
-  }
   //
   *out << cgicc::tr();
   //
@@ -5144,14 +5141,6 @@ void EmuPeripheralCrateConfig::ChamberTests(xgi::Input * in, xgi::Output * out )
   for(int i=0; i<32; ++i) *out << cgicc::option().set("value", toolbox::toString("%d", i)) << i << cgicc::option() << std::endl;
   *out << cgicc::select() << std::endl;
   *out << cgicc::td();
-  if (thisTMB->GetHardwareVersion()>=2){
-    *out << cgicc::td().set("ALIGN", "left") << std::endl;
-    *out << cgicc::select().set("name", "groupME11AandB") << std::endl;
-    *out << cgicc::option().set("value", "yes") << "yes" << cgicc::option() << std::endl;
-    *out << cgicc::option().set("value", "no") << "no" << cgicc::option() << std::endl;
-    *out << cgicc::select() << std::endl;
-    *out << cgicc::td();
-  }
   *out << cgicc::td();
   *out << cgicc::input().set("type","submit").set("value", "CFEB RX Delay Scan").set("style", "color:blue") << std::endl;
   *out << cgicc::td();
@@ -5779,7 +5768,6 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScan(xgi::Input * in, xgi::Output
   int halfstrip = 16;
   bool print_data = false;
   unsigned cfeb_phase = 0x0;
-  bool groupME11AandB = false;
 
   //
   name = cgi.getElement("time_delay");
@@ -5807,10 +5795,6 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScan(xgi::Input * in, xgi::Output
     cfeb_phase = cgi["cfeb_phase"]->getIntegerValue();
   }
   //
-  name = cgi.getElement("groupME11AandB");
-  if(name != cgi.getElements().end()) {
-    groupME11AandB = cgi["groupME11AandB"]->getValue() == "yes";
-  }
   
   std::cout << "time_delay: " << time_delay << std::endl;
   std::cout << "cfeb_num: " << cfeb_num << std::endl;
@@ -5818,10 +5802,9 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScan(xgi::Input * in, xgi::Output
   std::cout << "pattern: " << pattern << std::endl;
   std::cout << "halfstrip: " << halfstrip << std::endl;
   std::cout << "cfeb_phase: " << cfeb_phase << std::endl;
-  std::cout << "groupME11AandB: "<< groupME11AandB << std::endl;
   //
   MyTest[tmb][current_crate_].RedirectOutput(&ChamberTestsOutput[tmb][current_crate_]);
-  MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase, groupME11AandB);
+  MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase);
   MyTest[tmb][current_crate_].RedirectOutput(&std::cout);
   //
   this->ChamberTests(in,out);
@@ -5987,8 +5970,6 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_me11(xgi::Input * in, 
 	int halfstrip = -1;
 	bool print_data = true;
 	unsigned cfeb_phase = 32;
-	bool groupME11AandB = true;
-	
 	//
 	
 	std::cout << "time_delay: " << time_delay << std::endl;
@@ -5997,7 +5978,6 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_me11(xgi::Input * in, 
 	std::cout << "pattern: " << pattern << std::endl;
 	std::cout << "halfstrip: " << halfstrip << std::endl;
 	std::cout << "cfeb_phase: " << cfeb_phase << std::endl;
-	std::cout << "groupME11AandB: "<< groupME11AandB << std::endl;
 	//
 	//
 	if(thisCrate->GetTMB(tmbVector[tmb]->slot())->GetHardwareVersion() != 2) {
@@ -6019,7 +5999,7 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_me11(xgi::Input * in, 
 	web_backup.close();
 	//
 	MyTest[tmb][current_crate_].RedirectOutput(&ChamberTestsOutput[tmb][current_crate_]);
-	MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase, groupME11AandB);
+	MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase);
 	MyTest[tmb][current_crate_].RedirectOutput(&std::cout);
 	//
 	web_backup.open("/tmp/webout_backup_fullcrate.txt", std::ios::app);
@@ -6099,7 +6079,6 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_non_me11(xgi::Input * 
 	int halfstrip = -1;
 	bool print_data = true;
 	unsigned cfeb_phase = 32;
-	bool groupME11AandB = true;
 	//
 	
 	std::cout << "time_delay: " << time_delay << std::endl;
@@ -6108,7 +6087,6 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_non_me11(xgi::Input * 
 	std::cout << "pattern: " << pattern << std::endl;
 	std::cout << "halfstrip: " << halfstrip << std::endl;
 	std::cout << "cfeb_phase: " << cfeb_phase << std::endl;
-	std::cout << "groupME11AandB: " << groupME11AandB << std::endl;
 	//
 	//
 	if(thisCrate->GetTMB(tmbVector[tmb]->slot())->GetHardwareVersion() == 2) {
@@ -6130,7 +6108,7 @@ void EmuPeripheralCrateConfig::CFEBTimingSimpleScanSystem_non_me11(xgi::Input * 
 	web_backup.close();
 	//
 	MyTest[tmb][current_crate_].RedirectOutput(&ChamberTestsOutput[tmb][current_crate_]);
-	MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase, groupME11AandB);
+	MyTest[tmb][current_crate_].CFEBTiming_with_Posnegs_simple_routine(time_delay, cfeb_num, layers, pattern, halfstrip, print_data, cfeb_phase);
 	MyTest[tmb][current_crate_].RedirectOutput(&std::cout);
 	//
 	web_backup.open("/tmp/webout_backup_fullcrate.txt", std::ios::app);

--- a/emuDCS/PeripheralApps/src/common/XMLParser.cc
+++ b/emuDCS/PeripheralApps/src/common/XMLParser.cc
@@ -632,15 +632,20 @@ void XMLParser::TMBParser(xercesc::DOMNode * pNode, Crate * theCrate, Chamber * 
     if (fillInt("cfeb0123posneg",value))     { tmb_->SetCfeb0123RxPosNeg(value);     }
     //
     //0X11C
-    if (fillInt("cfeb0_rxd_int_delay",value)) { tmb_->SetCFEB0RxdIntDelay(value); }
-    if (fillInt("cfeb1_rxd_int_delay",value)) { tmb_->SetCFEB1RxdIntDelay(value); }
-    if (fillInt("cfeb2_rxd_int_delay",value)) { tmb_->SetCFEB2RxdIntDelay(value); }
-    if (fillInt("cfeb3_rxd_int_delay",value)) { tmb_->SetCFEB3RxdIntDelay(value); }
+    if (tmb_->GetHardwareVersion()<2){
+      if (fillInt("cfeb0_rxd_int_delay",value)) { tmb_->SetCFEB0RxdIntDelay(value); }
+      if (fillInt("cfeb1_rxd_int_delay",value)) { tmb_->SetCFEB1RxdIntDelay(value); }
+      if (fillInt("cfeb2_rxd_int_delay",value)) { tmb_->SetCFEB2RxdIntDelay(value); }
+      if (fillInt("cfeb3_rxd_int_delay",value)) { tmb_->SetCFEB3RxdIntDelay(value); }
+    }
     //
     //0X11E
-    if (fillInt("cfeb4_rxd_int_delay",value)) { tmb_->SetCFEB4RxdIntDelay(value); }
-    if (fillInt("cfeb5_rxd_int_delay",value)) { tmb_->SetCFEB5RxdIntDelay(value); }
-    if (fillInt("cfeb6_rxd_int_delay",value)) { tmb_->SetCFEB6RxdIntDelay(value); }
+    if (tmb_->GetHardwareVersion()<2){
+      if (fillInt("cfeb4_rxd_int_delay",value)) { tmb_->SetCFEB4RxdIntDelay(value); }
+    } else {
+      if (fillInt("cfeb0123_rxd_int_delay",value)) { tmb_->SetCFEB0123RxdIntDelay(value); }
+      if (fillInt("cfeb456_rxd_int_delay",value)) { tmb_->SetCFEB456RxdIntDelay(value); }
+    }
     //
     //0X122
     if (fillInt("cfeb_badbits_block",value)) { tmb_->SetCFEBBadBitsBlock(value); }

--- a/emuDCS/PeripheralApps/src/common/XMLParser.cc
+++ b/emuDCS/PeripheralApps/src/common/XMLParser.cc
@@ -593,56 +593,67 @@ void XMLParser::TMBParser(xercesc::DOMNode * pNode, Crate * theCrate, Chamber * 
     if (fillInt("alct_tx_clock_delay",value)) { tmb_->SetAlctTxClockDelay(value); }
     if (fillInt("alct_tx_posneg"     ,value)) { tmb_->SetAlctTxPosNeg(value);     }
     //
-    //0X112
-    if (fillInt("cfeb0delay"     ,value)) { tmb_->SetCfeb0RxClockDelay(value); }
-    if (fillInt("cfeb0posneg",value))     { tmb_->SetCfeb0RxPosNeg(value);     }
+
+    if (not tmb_->ExpectedTmbFirmwareConfigIsSet()) throw "TMB Expected Firmware Is Not Set";
+    if (tmb_->HasGroupedME11ABCFEBRxValues() <= 0){
+      //0X112
+      if (fillInt("cfeb0delay"     ,value)) { tmb_->SetCfeb0RxClockDelay(value); }
+      if (fillInt("cfeb0posneg",value))     { tmb_->SetCfeb0RxPosNeg(value);     }
+      //
+      //0X114
+      if (fillInt("cfeb1delay"     ,value)) { tmb_->SetCfeb1RxClockDelay(value); }
+      if (fillInt("cfeb1posneg",value))     { tmb_->SetCfeb1RxPosNeg(value);     }
+      //
+      //0X116
+      if (fillInt("cfeb2delay"     ,value)) { tmb_->SetCfeb2RxClockDelay(value); }
+      if (fillInt("cfeb2posneg",value))     { tmb_->SetCfeb2RxPosNeg(value);     }
+      //
+      //0X118
+      if (fillInt("cfeb3delay"     ,value)) { tmb_->SetCfeb3RxClockDelay(value); }
+      if (fillInt("cfeb3posneg",value))     { tmb_->SetCfeb3RxPosNeg(value);     }
+      //
+      //0X11A
+      if (fillInt("cfeb4delay"     ,value)) { tmb_->SetCfeb4RxClockDelay(value); }
+      if (fillInt("cfeb4posneg",value))     { tmb_->SetCfeb4RxPosNeg(value);     }
+      //
+      if (tmb_->GetHardwareVersion() ==2){
+	//0X16A
+	if (fillInt("cfeb5delay"     ,value)) { tmb_->SetCfeb5RxClockDelay(value); }
+	if (fillInt("cfeb5posneg",value))     { tmb_->SetCfeb5RxPosNeg(value);     }
+	//
+	//0X16C
+	if (fillInt("cfeb6delay"     ,value)) { tmb_->SetCfeb6RxClockDelay(value); }
+	if (fillInt("cfeb6posneg",value))     { tmb_->SetCfeb6RxPosNeg(value);     }	
+      }
+    }
     //
-    //0X114
-    if (fillInt("cfeb1delay"     ,value)) { tmb_->SetCfeb1RxClockDelay(value); }
-    if (fillInt("cfeb1posneg",value))     { tmb_->SetCfeb1RxPosNeg(value);     }
+    if (tmb_->HasGroupedME11ABCFEBRxValues() == 1){
+      //
+      //0X16A
+      if (fillInt("cfeb456delay"     ,value)) { tmb_->SetCfeb456RxClockDelay(value); }
+      if (fillInt("cfeb456posneg",value))     { tmb_->SetCfeb456RxPosNeg(value);     }
+      //
+      //0X16C
+      if (fillInt("cfeb0123delay"     ,value)) { tmb_->SetCfeb0123RxClockDelay(value); }
+      if (fillInt("cfeb0123posneg",value))     { tmb_->SetCfeb0123RxPosNeg(value);     }
+    }
     //
-    //0X116
-    if (fillInt("cfeb2delay"     ,value)) { tmb_->SetCfeb2RxClockDelay(value); }
-    if (fillInt("cfeb2posneg",value))     { tmb_->SetCfeb2RxPosNeg(value);     }
-    //
-    //0X118
-    if (fillInt("cfeb3delay"     ,value)) { tmb_->SetCfeb3RxClockDelay(value); }
-    if (fillInt("cfeb3posneg",value))     { tmb_->SetCfeb3RxPosNeg(value);     }
-    //
-    //0X11A
-    if (fillInt("cfeb4delay"     ,value)) { tmb_->SetCfeb4RxClockDelay(value); }
-    if (fillInt("cfeb4posneg",value))     { tmb_->SetCfeb4RxPosNeg(value);     }
-    //
-    //
-    //0X16A
-    if (fillInt("cfeb5delay"     ,value)) { tmb_->SetCfeb5RxClockDelay(value); }
-    if (fillInt("cfeb5posneg",value))     { tmb_->SetCfeb5RxPosNeg(value);     }
-    //
-    //0X16C
-    if (fillInt("cfeb6delay"     ,value)) { tmb_->SetCfeb6RxClockDelay(value); }
-    if (fillInt("cfeb6posneg",value))     { tmb_->SetCfeb6RxPosNeg(value);     }
-    //
-    //
-    //0X16A
-    if (fillInt("cfeb456delay"     ,value)) { tmb_->SetCfeb456RxClockDelay(value); }
-    if (fillInt("cfeb456posneg",value))     { tmb_->SetCfeb456RxPosNeg(value);     }
-    //
-    //0X16C
-    if (fillInt("cfeb0123delay"     ,value)) { tmb_->SetCfeb0123RxClockDelay(value); }
-    if (fillInt("cfeb0123posneg",value))     { tmb_->SetCfeb0123RxPosNeg(value);     }
-    //
-    //0X11C
-    if (tmb_->GetHardwareVersion()<2){
+    if (tmb_->HasGroupedME11ABCFEBRxValues() <= 0){
+      //0X11C
       if (fillInt("cfeb0_rxd_int_delay",value)) { tmb_->SetCFEB0RxdIntDelay(value); }
       if (fillInt("cfeb1_rxd_int_delay",value)) { tmb_->SetCFEB1RxdIntDelay(value); }
       if (fillInt("cfeb2_rxd_int_delay",value)) { tmb_->SetCFEB2RxdIntDelay(value); }
       if (fillInt("cfeb3_rxd_int_delay",value)) { tmb_->SetCFEB3RxdIntDelay(value); }
+      //0X11E
+      if (fillInt("cfeb4_rxd_int_delay",value)) { tmb_->SetCFEB4RxdIntDelay(value); }
+      if (tmb_->GetHardwareVersion() ==2){
+      //0X11E
+	if (fillInt("cfeb5_rxd_int_delay",value)) { tmb_->SetCFEB5RxdIntDelay(value); }
+	if (fillInt("cfeb6_rxd_int_delay",value)) { tmb_->SetCFEB6RxdIntDelay(value); }
+      }
     }
     //
-    //0X11E
-    if (tmb_->GetHardwareVersion()<2){
-      if (fillInt("cfeb4_rxd_int_delay",value)) { tmb_->SetCFEB4RxdIntDelay(value); }
-    } else {
+    if (tmb_->HasGroupedME11ABCFEBRxValues() == 1){
       if (fillInt("cfeb0123_rxd_int_delay",value)) { tmb_->SetCFEB0123RxdIntDelay(value); }
       if (fillInt("cfeb456_rxd_int_delay",value)) { tmb_->SetCFEB456RxdIntDelay(value); }
     }

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -405,6 +405,7 @@
 
 #include "emu/pc/VMEModule.h"
 #include <cstdio>
+#include <cassert>
 #include <vector>
 #include <string>
 #include <bitset>
@@ -2036,41 +2037,46 @@ public:
   // 0X11C = ADR_DELAY0_INT:  CFEB to TMB "interstage" delays
   //---------------------------------------------------------------------
   //!cfeb0_rxd_int_delay = delay of comparator data into CLCT algorithm (after latching) (bx)
-  inline void SetCFEB0RxdIntDelay(int cfeb0_rxd_int_delay) { cfeb0_rxd_int_delay_ = cfeb0_rxd_int_delay; }
-  inline int  GetCFEB0RxdIntDelay() { return cfeb0_rxd_int_delay_; }
-  inline int  GetReadCFEB0RxdIntDelay() { return read_cfeb0_rxd_int_delay_; }
+  inline void SetCFEB0RxdIntDelay(int cfeb0_rxd_int_delay) { assert(hardware_version_<2); cfeb0_rxd_int_delay_ = cfeb0_rxd_int_delay; }
+  inline int  GetCFEB0RxdIntDelay() { return hardware_version_ >= 2 ? cfeb0123_rxd_int_delay_ :  cfeb0_rxd_int_delay_; }
+  inline int  GetReadCFEB0RxdIntDelay() { return hardware_version_ >= 2 ? read_cfeb0123_rxd_int_delay_ : read_cfeb0_rxd_int_delay_; }
   //
   //!cfeb1_rxd_int_delay = delay of comparator data into CLCT algorithm (after latching) (bx)
-  inline void SetCFEB1RxdIntDelay(int cfeb1_rxd_int_delay) { cfeb1_rxd_int_delay_ = cfeb1_rxd_int_delay; }
-  inline int  GetCFEB1RxdIntDelay() { return cfeb1_rxd_int_delay_; }
-  inline int  GetReadCFEB1RxdIntDelay() { return read_cfeb1_rxd_int_delay_; }
+  inline void SetCFEB1RxdIntDelay(int cfeb1_rxd_int_delay) { assert(hardware_version_<2); cfeb1_rxd_int_delay_ = cfeb1_rxd_int_delay; }
+  inline int  GetCFEB1RxdIntDelay() { return hardware_version_ >= 2 ? cfeb0123_rxd_int_delay_ : cfeb1_rxd_int_delay_; }
+  inline int  GetReadCFEB1RxdIntDelay() { return hardware_version_ >= 2 ? read_cfeb0123_rxd_int_delay_ : read_cfeb1_rxd_int_delay_; }
   //
   //!cfeb2_rxd_int_delay = delay of comparator data into CLCT algorithm (after latching) (bx)
-  inline void SetCFEB2RxdIntDelay(int cfeb2_rxd_int_delay) { cfeb2_rxd_int_delay_ = cfeb2_rxd_int_delay; }
-  inline int  GetCFEB2RxdIntDelay() { return cfeb2_rxd_int_delay_; }
-  inline int  GetReadCFEB2RxdIntDelay() { return read_cfeb2_rxd_int_delay_; }
+  inline void SetCFEB2RxdIntDelay(int cfeb2_rxd_int_delay) { assert(hardware_version_<2); cfeb2_rxd_int_delay_ = cfeb2_rxd_int_delay; }
+  inline int  GetCFEB2RxdIntDelay() { return hardware_version_ >= 2 ? cfeb0123_rxd_int_delay_ : cfeb2_rxd_int_delay_; }
+  inline int  GetReadCFEB2RxdIntDelay() { return hardware_version_ >= 2 ? read_cfeb0123_rxd_int_delay_ : read_cfeb2_rxd_int_delay_; }
   //
   //!cfeb3_rxd_int_delay = delay of comparator data into CLCT algorithm (after latching) (bx)
-  inline void SetCFEB3RxdIntDelay(int cfeb3_rxd_int_delay) { cfeb3_rxd_int_delay_ = cfeb3_rxd_int_delay; }
-  inline int  GetCFEB3RxdIntDelay() { return cfeb3_rxd_int_delay_; }
-  inline int  GetReadCFEB3RxdIntDelay() { return read_cfeb3_rxd_int_delay_; }
+  inline void SetCFEB3RxdIntDelay(int cfeb3_rxd_int_delay) { assert(hardware_version_<2); cfeb3_rxd_int_delay_ = cfeb3_rxd_int_delay; }
+  inline int  GetCFEB3RxdIntDelay() { return hardware_version_ >= 2 ? cfeb0123_rxd_int_delay_ : cfeb3_rxd_int_delay_; }
+  inline int  GetReadCFEB3RxdIntDelay() { return hardware_version_ >= 2 ? read_cfeb0123_rxd_int_delay_ : read_cfeb3_rxd_int_delay_; }
   //
   //
   //---------------------------------------------------------------------
   // 0X11E = ADR_DELAY1_INT:  CFEB to TMB "interstage" delays
   //---------------------------------------------------------------------
   //!cfeb4_rxd_int_delay = delay of comparator data into CLCT algorithm (after latching) (bx)
-  inline void SetCFEB4RxdIntDelay(int cfeb4_rxd_int_delay) { cfeb4_rxd_int_delay_ = cfeb4_rxd_int_delay; }
-  inline int  GetCFEB4RxdIntDelay() { return cfeb4_rxd_int_delay_; }
-  inline int  GetReadCFEB4RxdIntDelay() { return read_cfeb4_rxd_int_delay_; }
+  inline void SetCFEB4RxdIntDelay(int cfeb4_rxd_int_delay) { assert(hardware_version_<2); cfeb4_rxd_int_delay_ = cfeb4_rxd_int_delay; }
+  inline int  GetCFEB4RxdIntDelay() { return hardware_version_ >= 2 ? cfeb456_rxd_int_delay_ : cfeb4_rxd_int_delay_; }
+  inline int  GetReadCFEB4RxdIntDelay() { return hardware_version_ >= 2 ? read_cfeb456_rxd_int_delay_ : read_cfeb4_rxd_int_delay_; }
   //
-  inline void SetCFEB5RxdIntDelay(int cfeb5_rxd_int_delay) { cfeb5_rxd_int_delay_ = cfeb5_rxd_int_delay; }
-  inline int  GetCFEB5RxdIntDelay() { return cfeb5_rxd_int_delay_; }
-  inline int  GetReadCFEB5RxdIntDelay() { return read_cfeb5_rxd_int_delay_; }
+  inline void SetCFEB456RxdIntDelay(int cfeb456_rxd_int_delay) { assert(hardware_version_>=2); cfeb456_rxd_int_delay_ = cfeb456_rxd_int_delay; }
+  inline int  GetCFEB456RxdIntDelay() { assert(hardware_version_>=2); return  cfeb456_rxd_int_delay_; }
+  inline int  GetReadCFEB456RxdIntDelay() { assert(hardware_version_>=2); return  read_cfeb456_rxd_int_delay_; }
+  //! to simplify coding patterns
+  inline int  GetCFEB5RxdIntDelay() { assert(hardware_version_>=2); return  cfeb456_rxd_int_delay_; }
+  inline int  GetReadCFEB5RxdIntDelay() { assert(hardware_version_>=2); return  read_cfeb456_rxd_int_delay_; }
+  inline int  GetCFEB6RxdIntDelay() { assert(hardware_version_>=2); return  cfeb456_rxd_int_delay_; }
+  inline int  GetReadCFEB6RxdIntDelay() { assert(hardware_version_>=2); return  read_cfeb456_rxd_int_delay_; }
   //
-  inline void SetCFEB6RxdIntDelay(int cfeb6_rxd_int_delay) { cfeb6_rxd_int_delay_ = cfeb6_rxd_int_delay; }
-  inline int  GetCFEB6RxdIntDelay() { return cfeb6_rxd_int_delay_; }
-  inline int  GetReadCFEB6RxdIntDelay() { return read_cfeb6_rxd_int_delay_; }
+  inline void SetCFEB0123RxdIntDelay(int cfeb0123_rxd_int_delay) { assert(hardware_version_>=2); cfeb0123_rxd_int_delay_ = cfeb0123_rxd_int_delay; }
+  inline int  GetCFEB0123RxdIntDelay() { assert(hardware_version_>=2); return cfeb0123_rxd_int_delay_; }
+  inline int  GetReadCFEB0123RxdIntDelay() { assert(hardware_version_>=2); return read_cfeb0123_rxd_int_delay_; }
   //
   //
   //---------------------------------------------------------------------
@@ -3596,12 +3602,13 @@ private:
   // 0X11E = ADR_DELAY1_INT:  CFEB to TMB "interstage" delays
   //---------------------------------------------------------------------
   int cfeb4_rxd_int_delay_;
-  int cfeb5_rxd_int_delay_;
-  int cfeb6_rxd_int_delay_;
+  int cfeb456_rxd_int_delay_;
+  int cfeb0123_rxd_int_delay_;
+  
   //
   int read_cfeb4_rxd_int_delay_; 
-  int read_cfeb5_rxd_int_delay_; 
-  int read_cfeb6_rxd_int_delay_; 
+  int read_cfeb456_rxd_int_delay_; 
+  int read_cfeb0123_rxd_int_delay_; 
   //
   //
   //---------------------------------------------------------------------

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -547,6 +547,16 @@ public:
   inline int  GetExpectedRatFirmwareYear() { return rat_firmware_year_; }
   //
   int  PowerComparator();
+
+  bool ExpectedTmbFirmwareConfigIsSet(){
+    return GetExpectedTmbFirmwareYear() > 0 && GetExpectedTmbFirmwareMonth() > 0 && GetExpectedTmbFirmwareDay() > 0;
+  }
+  int HasGroupedME11ABCFEBRxValues(){
+    if (GetHardwareVersion() < 2) return -1;
+    if (not ExpectedTmbFirmwareConfigIsSet() ) return -1;
+    if (GetExpectedTmbFirmwareYear() >= 2015 && GetExpectedTmbFirmwareMonth() >= 1 && GetExpectedTmbFirmwareDay() >= 20)  return 1;
+    else return 0;
+  }
   //
   // called by TRGMODE, depending on version_
   void trgmode_bprsq_alct();
@@ -715,9 +725,12 @@ public:
   int tmb_read_delays(int);
   //
   inline int  GetCfebRxClockDelay(int CFEB) {
-    int tmp[7] = { cfeb0_rx_clock_delay_, cfeb1_rx_clock_delay_, cfeb2_rx_clock_delay_, cfeb3_rx_clock_delay_, cfeb4_rx_clock_delay_, 
-		   cfeb5_rx_clock_delay_, cfeb6_rx_clock_delay_ };
-    return tmp[CFEB]; 
+    assert(CFEB < 5 || (CFEB < 7 && GetHardwareVersion() == 2));
+    
+    int tmp[5] = { cfeb0_rx_clock_delay_, cfeb1_rx_clock_delay_, cfeb2_rx_clock_delay_, cfeb3_rx_clock_delay_, cfeb4_rx_clock_delay_};
+    if (CFEB < 5) return tmp[CFEB];
+    else if (CFEB == 5) return GetCfeb5RxClockDelay();
+    else return GetCfeb6RxClockDelay();
   }
   //
   //void SetVersion(std::string version) {version_ = version;}
@@ -1896,187 +1909,205 @@ public:
   //---------------------------------------------------------------------
   //0X112 = ADR_PHASER2 digital phase shifter setting for cfeb0_rx
   //---------------------------------------------------------------------
-  inline void SetCfeb0RxClockDelay(int cfeb0_rx_clock_delay) { cfeb0_rx_clock_delay_ = cfeb0_rx_clock_delay; }
-  inline void SetCFEB0delay(int cfeb0_rx_clock_delay)        { cfeb0_rx_clock_delay_ = cfeb0_rx_clock_delay; } //legacy setter
+  inline void SetCfeb0RxClockDelay(int cfeb0_rx_clock_delay) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb0_rx_clock_delay_ = cfeb0_rx_clock_delay; }
+  inline void SetCFEB0delay(int cfeb0_rx_clock_delay)        { SetCfeb0RxClockDelay(cfeb0_rx_clock_delay); } //legacy setter
   inline int  GetCfeb0RxClockDelay() { return cfeb0_rx_clock_delay_; }
-  inline int  GetCFEB0delay()        { return cfeb0_rx_clock_delay_; } //legacy getter
+  inline int  GetCFEB0delay()        { return GetCfeb0RxClockDelay(); } //legacy getter
   inline int  GetReadCfeb0RxClockDelay() { return read_cfeb0_rx_clock_delay_; }
   //
-  inline void SetCfeb0RxPosNeg(int cfeb0_rx_posneg) { cfeb0_rx_posneg_ = cfeb0_rx_posneg; }
+  inline void SetCfeb0RxPosNeg(int cfeb0_rx_posneg) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb0_rx_posneg_ = cfeb0_rx_posneg; }
   inline int  GetCfeb0RxPosNeg() { return cfeb0_rx_posneg_; }
   inline int  GetReadCfeb0RxPosNeg() { return read_cfeb0_rx_posneg_; }
   //
   //---------------------------------------------------------------------
   //0X114 = ADR_PHASER3 digital phase shifter setting for cfeb1_rx
   //---------------------------------------------------------------------
-  inline void SetCfeb1RxClockDelay(int cfeb1_rx_clock_delay) { cfeb1_rx_clock_delay_ = cfeb1_rx_clock_delay; }
-  inline void SetCFEB1delay(int cfeb1_rx_clock_delay)        { cfeb1_rx_clock_delay_ = cfeb1_rx_clock_delay; } //legacy setter
+  inline void SetCfeb1RxClockDelay(int cfeb1_rx_clock_delay) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb1_rx_clock_delay_ = cfeb1_rx_clock_delay; }
+  inline void SetCFEB1delay(int cfeb1_rx_clock_delay)        { SetCfeb1RxClockDelay(cfeb1_rx_clock_delay); } //legacy setter
   inline int  GetCfeb1RxClockDelay() { return cfeb1_rx_clock_delay_; }
-  inline int  GetCFEB1delay()        { return cfeb1_rx_clock_delay_; } //legacy getter
+  inline int  GetCFEB1delay()        { return GetCfeb1RxClockDelay(); } //legacy getter
   inline int  GetReadCfeb1RxClockDelay() { return read_cfeb1_rx_clock_delay_; }
   //
-  inline void SetCfeb1RxPosNeg(int cfeb1_rx_posneg) { cfeb1_rx_posneg_ = cfeb1_rx_posneg; }
+  inline void SetCfeb1RxPosNeg(int cfeb1_rx_posneg) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb1_rx_posneg_ = cfeb1_rx_posneg; }
   inline int  GetCfeb1RxPosNeg() { return cfeb1_rx_posneg_; }
   inline int  GetReadCfeb1RxPosNeg() { return read_cfeb1_rx_posneg_; }
   //
   //---------------------------------------------------------------------
   //0X116 = ADR_PHASER4 digital phase shifter setting for cfeb2_rx
   //---------------------------------------------------------------------
-  inline void SetCfeb2RxClockDelay(int cfeb2_rx_clock_delay) { cfeb2_rx_clock_delay_ = cfeb2_rx_clock_delay; }
-  inline void SetCFEB2delay(int cfeb2_rx_clock_delay)        { cfeb2_rx_clock_delay_ = cfeb2_rx_clock_delay; } //legacy setter
+  inline void SetCfeb2RxClockDelay(int cfeb2_rx_clock_delay) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb2_rx_clock_delay_ = cfeb2_rx_clock_delay; }
+  inline void SetCFEB2delay(int cfeb2_rx_clock_delay)        { SetCfeb2RxClockDelay(cfeb2_rx_clock_delay); } //legacy setter
   inline int  GetCfeb2RxClockDelay() { return cfeb2_rx_clock_delay_; }
-  inline int  GetCFEB2delay()        { return cfeb2_rx_clock_delay_; } //legacy getter
+  inline int  GetCFEB2delay()        { return GetCfeb2RxClockDelay(); } //legacy getter
   inline int  GetReadCfeb2RxClockDelay() { return read_cfeb2_rx_clock_delay_; }
   //
-  inline void SetCfeb2RxPosNeg(int cfeb2_rx_posneg) { cfeb2_rx_posneg_ = cfeb2_rx_posneg; }
+  inline void SetCfeb2RxPosNeg(int cfeb2_rx_posneg) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb2_rx_posneg_ = cfeb2_rx_posneg; }
   inline int  GetCfeb2RxPosNeg() { return cfeb2_rx_posneg_; }
   inline int  GetReadCfeb2RxPosNeg() { return read_cfeb2_rx_posneg_; }
   //
   //---------------------------------------------------------------------
   //0X118 = ADR_PHASER5 digital phase shifter setting for cfeb3_rx
   //---------------------------------------------------------------------
-  inline void SetCfeb3RxClockDelay(int cfeb3_rx_clock_delay) { cfeb3_rx_clock_delay_ = cfeb3_rx_clock_delay; }
-  inline void SetCFEB3delay(int cfeb3_rx_clock_delay)        { cfeb3_rx_clock_delay_ = cfeb3_rx_clock_delay; } //legacy setter
+  inline void SetCfeb3RxClockDelay(int cfeb3_rx_clock_delay) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb3_rx_clock_delay_ = cfeb3_rx_clock_delay; }
+  inline void SetCFEB3delay(int cfeb3_rx_clock_delay)        { SetCfeb3RxClockDelay(cfeb3_rx_clock_delay); } //legacy setter
   inline int  GetCfeb3RxClockDelay() { return cfeb3_rx_clock_delay_; }
-  inline int  GetCFEB3delay()        { return cfeb3_rx_clock_delay_; } //legacy getter
+  inline int  GetCFEB3delay()        { return GetCfeb3RxClockDelay(); } //legacy getter
   inline int  GetReadCfeb3RxClockDelay() { return read_cfeb3_rx_clock_delay_; }
   //
-  inline void SetCfeb3RxPosNeg(int cfeb3_rx_posneg) { cfeb3_rx_posneg_ = cfeb3_rx_posneg; }
+  inline void SetCfeb3RxPosNeg(int cfeb3_rx_posneg) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb3_rx_posneg_ = cfeb3_rx_posneg; }
   inline int  GetCfeb3RxPosNeg() { return cfeb3_rx_posneg_; }
   inline int  GetReadCfeb3RxPosNeg() { return read_cfeb3_rx_posneg_; }
   //
   //---------------------------------------------------------------------
   //0X11A = ADR_PHASER6 digital phase shifter setting for cfeb4_rx
   //---------------------------------------------------------------------
-  inline void SetCfeb4RxClockDelay(int cfeb4_rx_clock_delay) { cfeb4_rx_clock_delay_ = cfeb4_rx_clock_delay; }  
-  inline void SetCFEB4delay(int cfeb4_rx_clock_delay)        { cfeb4_rx_clock_delay_ = cfeb4_rx_clock_delay; } //legacy setter
+  inline void SetCfeb4RxClockDelay(int cfeb4_rx_clock_delay) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb4_rx_clock_delay_ = cfeb4_rx_clock_delay; }  
+  inline void SetCFEB4delay(int cfeb4_rx_clock_delay)        { SetCfeb4RxClockDelay(cfeb4_rx_clock_delay); } //legacy setter
   inline int  GetCfeb4RxClockDelay() { return cfeb4_rx_clock_delay_; }
-  inline int  GetCFEB4delay()        { return cfeb4_rx_clock_delay_; } //legacy getter
+  inline int  GetCFEB4delay()        { return GetCfeb4RxClockDelay(); } //legacy getter
   inline int  GetReadCfeb4RxClockDelay() { return read_cfeb4_rx_clock_delay_; }
   //
-  inline void SetCfeb4RxPosNeg(int cfeb4_rx_posneg) { cfeb4_rx_posneg_ = cfeb4_rx_posneg; }
+  inline void SetCfeb4RxPosNeg(int cfeb4_rx_posneg) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb4_rx_posneg_ = cfeb4_rx_posneg; }
   inline int  GetCfeb4RxPosNeg() { return cfeb4_rx_posneg_; }
   inline int  GetReadCfeb4RxPosNeg() { return read_cfeb4_rx_posneg_; }
   //
   //---------------------------------------------------------------------
   //0X16A = ADR_V6_PHASER7 digital phase shifter setting for A side dcfebs - cfeb456_rx
   //---------------------------------------------------------------------
-  inline void SetCfeb5RxClockDelay(int cfeb5_rx_clock_delay) { cfeb5_rx_clock_delay_ = cfeb5_rx_clock_delay; }
+  inline void SetCfeb5RxClockDelay(int cfeb5_rx_clock_delay) { assert(HasGroupedME11ABCFEBRxValues()==0); cfeb5_rx_clock_delay_ = cfeb5_rx_clock_delay; }
+  inline void SetCFEB5delay(int cfeb5_rx_clock_delay)        { SetCfeb5RxClockDelay(cfeb5_rx_clock_delay); } //legacy setter
+  inline int  GetCfeb5RxClockDelay() { return cfeb5_rx_clock_delay_; }
+  inline int  GetCFEB5delay()        { return GetCFEB5delay(); } //legacy getter
+  inline int  GetReadCfeb5RxClockDelay() { return read_cfeb5_rx_clock_delay_; }
+  //
+  inline void SetCfeb5RxPosNeg(int cfeb5_rx_posneg) { assert(HasGroupedME11ABCFEBRxValues()==0); cfeb5_rx_posneg_ = cfeb5_rx_posneg; }
+  inline int  GetCfeb5RxPosNeg() { return cfeb5_rx_posneg_; }
+  inline int  GetReadCfeb5RxPosNeg() { return read_cfeb5_rx_posneg_; }
+
   inline void SetCfeb456RxClockDelay(int cfeb456_rx_clock_delay) { 
+    assert(HasGroupedME11ABCFEBRxValues()==1);
     cfeb4_rx_clock_delay_ = cfeb456_rx_clock_delay; 
     cfeb5_rx_clock_delay_ = cfeb456_rx_clock_delay; 
     cfeb6_rx_clock_delay_ = cfeb456_rx_clock_delay; 
     cfeb456_rx_clock_delay_ = cfeb456_rx_clock_delay; 
   }
-  inline void SetCFEB5delay(int cfeb5_rx_clock_delay)        { cfeb5_rx_clock_delay_ = cfeb5_rx_clock_delay; } //legacy setter
-  inline void SetCFEB456delay(int cfeb456_rx_clock_delay)        { 
-    cfeb4_rx_clock_delay_ = cfeb456_rx_clock_delay; 
-    cfeb5_rx_clock_delay_ = cfeb456_rx_clock_delay; 
-    cfeb6_rx_clock_delay_ = cfeb456_rx_clock_delay; 
-    cfeb456_rx_clock_delay_ = cfeb456_rx_clock_delay; 
-  } //legacy setter
-  inline int  GetCfeb5RxClockDelay() { return cfeb5_rx_clock_delay_; }
+  inline void SetCFEB456delay(int cfeb456_rx_clock_delay)        { SetCfeb456RxClockDelay(cfeb456_rx_clock_delay);  } //legacy setter
   inline int  GetCfeb456RxClockDelay() { return cfeb456_rx_clock_delay_; }
-  inline int  GetCFEB5delay()        { return cfeb5_rx_clock_delay_; } //legacy getter
-  inline int  GetCFEB456delay()        { return cfeb456_rx_clock_delay_; } //legacy getter
-  inline int  GetReadCfeb5RxClockDelay() { return read_cfeb5_rx_clock_delay_; }
+  inline int  GetCFEB456delay()        { return GetCFEB456delay(); } //legacy getter
   inline int  GetReadCfeb456RxClockDelay() { return read_cfeb456_rx_clock_delay_; }
   //
-  inline void SetCfeb5RxPosNeg(int cfeb5_rx_posneg) { cfeb5_rx_posneg_ = cfeb5_rx_posneg; }
   inline void SetCfeb456RxPosNeg(int cfeb456_rx_posneg) { 
+    assert(HasGroupedME11ABCFEBRxValues()==1);
     cfeb4_rx_posneg_ = cfeb456_rx_posneg; 
     cfeb5_rx_posneg_ = cfeb456_rx_posneg; 
     cfeb6_rx_posneg_ = cfeb456_rx_posneg; 
     cfeb456_rx_posneg_ = cfeb456_rx_posneg; 
   }
-  inline int  GetCfeb5RxPosNeg() { return cfeb5_rx_posneg_; }
   inline int  GetCfeb456RxPosNeg() { return cfeb456_rx_posneg_; }
-  inline int  GetReadCfeb5RxPosNeg() { return read_cfeb5_rx_posneg_; }
   inline int  GetReadCfeb456RxPosNeg() { return read_cfeb456_rx_posneg_; }
   //
   //---------------------------------------------------------------------
   //0X16C = ADR_V6_PHASER8 digital phase shifter setting for B side dcfebs - cfeb0123_rx
   //---------------------------------------------------------------------
-  inline void SetCfeb6RxClockDelay(int cfeb6_rx_clock_delay) { cfeb6_rx_clock_delay_ = cfeb6_rx_clock_delay; }
+  inline void SetCfeb6RxClockDelay(int cfeb6_rx_clock_delay) { assert(HasGroupedME11ABCFEBRxValues()==0); cfeb6_rx_clock_delay_ = cfeb6_rx_clock_delay; }
+  inline void SetCFEB6delay(int cfeb6_rx_clock_delay)        { SetCfeb6RxClockDelay(cfeb6_rx_clock_delay); } //legacy setter
+  inline int  GetCfeb6RxClockDelay() { return cfeb6_rx_clock_delay_; }
+  inline int  GetCFEB6delay()        { return GetCfeb6RxClockDelay(); } //legacy getter
+  inline int  GetReadCfeb6RxClockDelay() { return read_cfeb6_rx_clock_delay_; }
+  inline void SetCfeb6RxPosNeg(int cfeb6_rx_posneg) { cfeb6_rx_posneg_ = cfeb6_rx_posneg; }
+  inline int  GetCfeb6RxPosNeg() { return cfeb6_rx_posneg_; }
+  inline int  GetReadCfeb6RxPosNeg() { return read_cfeb6_rx_posneg_; }
+
   inline void SetCfeb0123RxClockDelay(int cfeb0123_rx_clock_delay) { 
+    assert(HasGroupedME11ABCFEBRxValues()==1);
     cfeb0_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
     cfeb1_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
     cfeb2_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
     cfeb3_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
     cfeb0123_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
   }
-  inline void SetCFEB6delay(int cfeb6_rx_clock_delay)        { cfeb6_rx_clock_delay_ = cfeb6_rx_clock_delay; } //legacy setter
-  inline void SetCFEB0123delay(int cfeb0123_rx_clock_delay)        { 
-    cfeb0_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
-    cfeb1_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
-    cfeb2_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
-    cfeb3_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
-    cfeb0123_rx_clock_delay_ = cfeb0123_rx_clock_delay; 
-  } //legacy setter
-  inline int  GetCfeb6RxClockDelay() { return cfeb6_rx_clock_delay_; }
+  inline void SetCFEB0123delay(int cfeb0123_rx_clock_delay)        { SetCfeb0123RxClockDelay(cfeb0123_rx_clock_delay);  } //legacy setter
   inline int  GetCfeb0123RxClockDelay() { return cfeb0123_rx_clock_delay_; }
-  inline int  GetCFEB6delay()        { return cfeb6_rx_clock_delay_; } //legacy getter
-  inline int  GetCFEB0123delay()        { return cfeb0123_rx_clock_delay_; } //legacy getter
-  inline int  GetReadCfeb6RxClockDelay() { return read_cfeb6_rx_clock_delay_; }
+  inline int  GetCFEB0123delay()        { return GetCfeb0123RxClockDelay(); } //legacy getter
   inline int  GetReadCfeb0123RxClockDelay() { return read_cfeb0123_rx_clock_delay_; }
   //
-  inline void SetCfeb6RxPosNeg(int cfeb6_rx_posneg) { cfeb6_rx_posneg_ = cfeb6_rx_posneg; }
   inline void SetCfeb0123RxPosNeg(int cfeb0123_rx_posneg) { 
+    assert(HasGroupedME11ABCFEBRxValues()==1);
     cfeb0_rx_posneg_ = cfeb0123_rx_posneg; 
     cfeb1_rx_posneg_ = cfeb0123_rx_posneg; 
     cfeb2_rx_posneg_ = cfeb0123_rx_posneg; 
     cfeb3_rx_posneg_ = cfeb0123_rx_posneg; 
     cfeb0123_rx_posneg_ = cfeb0123_rx_posneg; 
   }
-  inline int  GetCfeb6RxPosNeg() { return cfeb6_rx_posneg_; }
   inline int  GetCfeb0123RxPosNeg() { return cfeb0123_rx_posneg_; }
-  inline int  GetReadCfeb6RxPosNeg() { return read_cfeb6_rx_posneg_; }
   inline int  GetReadCfeb0123RxPosNeg() { return read_cfeb0123_rx_posneg_; }
   //
   //---------------------------------------------------------------------
   // 0X11C = ADR_DELAY0_INT:  CFEB to TMB "interstage" delays
   //---------------------------------------------------------------------
   //!cfeb0_rxd_int_delay = delay of comparator data into CLCT algorithm (after latching) (bx)
-  inline void SetCFEB0RxdIntDelay(int cfeb0_rxd_int_delay) { assert(hardware_version_<2); cfeb0_rxd_int_delay_ = cfeb0_rxd_int_delay; }
-  inline int  GetCFEB0RxdIntDelay() { return hardware_version_ >= 2 ? cfeb0123_rxd_int_delay_ :  cfeb0_rxd_int_delay_; }
-  inline int  GetReadCFEB0RxdIntDelay() { return hardware_version_ >= 2 ? read_cfeb0123_rxd_int_delay_ : read_cfeb0_rxd_int_delay_; }
+  inline void SetCFEB0RxdIntDelay(int cfeb0_rxd_int_delay) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb0_rxd_int_delay_ = cfeb0_rxd_int_delay; }
+  inline int  GetCFEB0RxdIntDelay() { return HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rxd_int_delay_ :  cfeb0_rxd_int_delay_; }
+  inline int  GetReadCFEB0RxdIntDelay() { return HasGroupedME11ABCFEBRxValues() == 1 ? read_cfeb0123_rxd_int_delay_ : read_cfeb0_rxd_int_delay_; }
   //
   //!cfeb1_rxd_int_delay = delay of comparator data into CLCT algorithm (after latching) (bx)
-  inline void SetCFEB1RxdIntDelay(int cfeb1_rxd_int_delay) { assert(hardware_version_<2); cfeb1_rxd_int_delay_ = cfeb1_rxd_int_delay; }
-  inline int  GetCFEB1RxdIntDelay() { return hardware_version_ >= 2 ? cfeb0123_rxd_int_delay_ : cfeb1_rxd_int_delay_; }
-  inline int  GetReadCFEB1RxdIntDelay() { return hardware_version_ >= 2 ? read_cfeb0123_rxd_int_delay_ : read_cfeb1_rxd_int_delay_; }
+  inline void SetCFEB1RxdIntDelay(int cfeb1_rxd_int_delay) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb1_rxd_int_delay_ = cfeb1_rxd_int_delay; }
+  inline int  GetCFEB1RxdIntDelay() { return HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rxd_int_delay_ : cfeb1_rxd_int_delay_; }
+  inline int  GetReadCFEB1RxdIntDelay() { return HasGroupedME11ABCFEBRxValues() == 1 ? read_cfeb0123_rxd_int_delay_ : read_cfeb1_rxd_int_delay_; }
   //
   //!cfeb2_rxd_int_delay = delay of comparator data into CLCT algorithm (after latching) (bx)
-  inline void SetCFEB2RxdIntDelay(int cfeb2_rxd_int_delay) { assert(hardware_version_<2); cfeb2_rxd_int_delay_ = cfeb2_rxd_int_delay; }
-  inline int  GetCFEB2RxdIntDelay() { return hardware_version_ >= 2 ? cfeb0123_rxd_int_delay_ : cfeb2_rxd_int_delay_; }
-  inline int  GetReadCFEB2RxdIntDelay() { return hardware_version_ >= 2 ? read_cfeb0123_rxd_int_delay_ : read_cfeb2_rxd_int_delay_; }
+  inline void SetCFEB2RxdIntDelay(int cfeb2_rxd_int_delay) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb2_rxd_int_delay_ = cfeb2_rxd_int_delay; }
+  inline int  GetCFEB2RxdIntDelay() { return HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rxd_int_delay_ : cfeb2_rxd_int_delay_; }
+  inline int  GetReadCFEB2RxdIntDelay() { return HasGroupedME11ABCFEBRxValues() == 1 ? read_cfeb0123_rxd_int_delay_ : read_cfeb2_rxd_int_delay_; }
   //
   //!cfeb3_rxd_int_delay = delay of comparator data into CLCT algorithm (after latching) (bx)
-  inline void SetCFEB3RxdIntDelay(int cfeb3_rxd_int_delay) { assert(hardware_version_<2); cfeb3_rxd_int_delay_ = cfeb3_rxd_int_delay; }
-  inline int  GetCFEB3RxdIntDelay() { return hardware_version_ >= 2 ? cfeb0123_rxd_int_delay_ : cfeb3_rxd_int_delay_; }
-  inline int  GetReadCFEB3RxdIntDelay() { return hardware_version_ >= 2 ? read_cfeb0123_rxd_int_delay_ : read_cfeb3_rxd_int_delay_; }
+  inline void SetCFEB3RxdIntDelay(int cfeb3_rxd_int_delay) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb3_rxd_int_delay_ = cfeb3_rxd_int_delay; }
+  inline int  GetCFEB3RxdIntDelay() { return HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rxd_int_delay_ : cfeb3_rxd_int_delay_; }
+  inline int  GetReadCFEB3RxdIntDelay() { return HasGroupedME11ABCFEBRxValues() == 1 ? read_cfeb0123_rxd_int_delay_ : read_cfeb3_rxd_int_delay_; }
   //
   //
   //---------------------------------------------------------------------
   // 0X11E = ADR_DELAY1_INT:  CFEB to TMB "interstage" delays
   //---------------------------------------------------------------------
   //!cfeb4_rxd_int_delay = delay of comparator data into CLCT algorithm (after latching) (bx)
-  inline void SetCFEB4RxdIntDelay(int cfeb4_rxd_int_delay) { assert(hardware_version_<2); cfeb4_rxd_int_delay_ = cfeb4_rxd_int_delay; }
-  inline int  GetCFEB4RxdIntDelay() { return hardware_version_ >= 2 ? cfeb456_rxd_int_delay_ : cfeb4_rxd_int_delay_; }
-  inline int  GetReadCFEB4RxdIntDelay() { return hardware_version_ >= 2 ? read_cfeb456_rxd_int_delay_ : read_cfeb4_rxd_int_delay_; }
+  inline void SetCFEB4RxdIntDelay(int cfeb4_rxd_int_delay) { assert(HasGroupedME11ABCFEBRxValues()<=0); cfeb4_rxd_int_delay_ = cfeb4_rxd_int_delay; }
+  inline int  GetCFEB4RxdIntDelay() { return HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rxd_int_delay_ : cfeb4_rxd_int_delay_; }
+  inline int  GetReadCFEB4RxdIntDelay() { return HasGroupedME11ABCFEBRxValues() == 1 ? read_cfeb456_rxd_int_delay_ : read_cfeb4_rxd_int_delay_; }
+  //! set is only for the special version
+  inline void SetCFEB5RxdIntDelay(int cfeb5_rxd_int_delay) { assert(HasGroupedME11ABCFEBRxValues()==0); cfeb5_rxd_int_delay_ = cfeb5_rxd_int_delay; }
+  inline int  GetCFEB5RxdIntDelay() { 
+    assert(HasGroupedME11ABCFEBRxValues()>=0); 
+    return HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rxd_int_delay_ : cfeb5_rxd_int_delay_; }
+  inline int  GetReadCFEB5RxdIntDelay() { 
+    assert(HasGroupedME11ABCFEBRxValues()>=0); 
+    return HasGroupedME11ABCFEBRxValues() == 1 ? read_cfeb456_rxd_int_delay_ : read_cfeb5_rxd_int_delay_; }
   //
-  inline void SetCFEB456RxdIntDelay(int cfeb456_rxd_int_delay) { assert(hardware_version_>=2); cfeb456_rxd_int_delay_ = cfeb456_rxd_int_delay; }
-  inline int  GetCFEB456RxdIntDelay() { assert(hardware_version_>=2); return  cfeb456_rxd_int_delay_; }
-  inline int  GetReadCFEB456RxdIntDelay() { assert(hardware_version_>=2); return  read_cfeb456_rxd_int_delay_; }
-  //! to simplify coding patterns
-  inline int  GetCFEB5RxdIntDelay() { assert(hardware_version_>=2); return  cfeb456_rxd_int_delay_; }
-  inline int  GetReadCFEB5RxdIntDelay() { assert(hardware_version_>=2); return  read_cfeb456_rxd_int_delay_; }
-  inline int  GetCFEB6RxdIntDelay() { assert(hardware_version_>=2); return  cfeb456_rxd_int_delay_; }
-  inline int  GetReadCFEB6RxdIntDelay() { assert(hardware_version_>=2); return  read_cfeb456_rxd_int_delay_; }
+  inline void SetCFEB6RxdIntDelay(int cfeb6_rxd_int_delay) { 
+    assert(HasGroupedME11ABCFEBRxValues()==0); cfeb6_rxd_int_delay_ = cfeb6_rxd_int_delay; }
+  inline int  GetCFEB6RxdIntDelay() { 
+    assert(HasGroupedME11ABCFEBRxValues()>=0); 
+    return HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rxd_int_delay_ : cfeb6_rxd_int_delay_; }
+  inline int  GetReadCFEB6RxdIntDelay() { 
+    assert(HasGroupedME11ABCFEBRxValues()>=0); 
+    return HasGroupedME11ABCFEBRxValues() == 1 ? read_cfeb456_rxd_int_delay_ : read_cfeb6_rxd_int_delay_; }
   //
-  inline void SetCFEB0123RxdIntDelay(int cfeb0123_rxd_int_delay) { assert(hardware_version_>=2); cfeb0123_rxd_int_delay_ = cfeb0123_rxd_int_delay; }
-  inline int  GetCFEB0123RxdIntDelay() { assert(hardware_version_>=2); return cfeb0123_rxd_int_delay_; }
-  inline int  GetReadCFEB0123RxdIntDelay() { assert(hardware_version_>=2); return read_cfeb0123_rxd_int_delay_; }
+  inline void SetCFEB0123RxdIntDelay(int cfeb0123_rxd_int_delay) { 
+    assert(HasGroupedME11ABCFEBRxValues()>0); 
+    cfeb0123_rxd_int_delay_ = cfeb0123_rxd_int_delay; 
+  }
+  inline int  GetCFEB0123RxdIntDelay() { 
+    assert(HasGroupedME11ABCFEBRxValues()>0); return  cfeb0123_rxd_int_delay_; }
+  inline int  GetReadCFEB0123RxdIntDelay() { 
+    assert(HasGroupedME11ABCFEBRxValues()>0); return  read_cfeb0123_rxd_int_delay_; }
+  //
+  inline void SetCFEB456RxdIntDelay(int cfeb456_rxd_int_delay) { 
+    assert(HasGroupedME11ABCFEBRxValues()>0); 
+    cfeb456_rxd_int_delay_ = cfeb456_rxd_int_delay; 
+  }
+  inline int  GetCFEB456RxdIntDelay() { 
+    assert(HasGroupedME11ABCFEBRxValues()>0); return  cfeb456_rxd_int_delay_; }
+  inline int  GetReadCFEB456RxdIntDelay() { 
+    assert(HasGroupedME11ABCFEBRxValues()>0); return  read_cfeb456_rxd_int_delay_; }
   //
   //
   //---------------------------------------------------------------------
@@ -3602,11 +3633,15 @@ private:
   // 0X11E = ADR_DELAY1_INT:  CFEB to TMB "interstage" delays
   //---------------------------------------------------------------------
   int cfeb4_rxd_int_delay_;
+  int cfeb5_rxd_int_delay_;
+  int cfeb6_rxd_int_delay_;
   int cfeb456_rxd_int_delay_;
   int cfeb0123_rxd_int_delay_;
   
   //
   int read_cfeb4_rxd_int_delay_; 
+  int read_cfeb5_rxd_int_delay_; 
+  int read_cfeb6_rxd_int_delay_; 
   int read_cfeb456_rxd_int_delay_; 
   int read_cfeb0123_rxd_int_delay_; 
   //

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
@@ -291,6 +291,7 @@ static const unsigned long int  phaser_cfeb3_rxd_adr    = 0x000118;
 static const unsigned long int  phaser_cfeb4_rxd_adr    = 0x00011A;
 static const unsigned long int  cfeb0_3_interstage_adr  = 0x00011C;
 static const unsigned long int  cfeb4_6_interstage_adr  = 0x00011E;
+static const unsigned long int  dcfeb_me11ab_interstage_adr  = 0x00011E;
 //
 static const unsigned long int  sync_err_control_adr    = 0x000120;
 static const unsigned long int  cfeb_badbits_ctrl_adr   = 0x000122;
@@ -2443,16 +2444,16 @@ const int cfeb4_rxd_int_delay_vmereg  =  cfeb4_6_interstage_adr;
 const int cfeb4_rxd_int_delay_bitlo   =  0;
 const int cfeb4_rxd_int_delay_bithi   =  3;
 const int cfeb4_rxd_int_delay_default =  0; 
+//! thse were called cfeb5_* and cfeb6_* before, these are grouped for me11
+const int cfeb456_rxd_int_delay_vmereg  =  dcfeb_me11ab_interstage_adr;
+const int cfeb456_rxd_int_delay_bitlo   =  4;
+const int cfeb456_rxd_int_delay_bithi   =  7;
+const int cfeb456_rxd_int_delay_default =  0; 
 //
-const int cfeb5_rxd_int_delay_vmereg  =  cfeb4_6_interstage_adr;
-const int cfeb5_rxd_int_delay_bitlo   =  4;
-const int cfeb5_rxd_int_delay_bithi   =  7;
-const int cfeb5_rxd_int_delay_default =  0; 
-//
-const int cfeb6_rxd_int_delay_vmereg  =  cfeb4_6_interstage_adr;
-const int cfeb6_rxd_int_delay_bitlo   =  8;
-const int cfeb6_rxd_int_delay_bithi   =  11;
-const int cfeb6_rxd_int_delay_default =  0; 
+const int cfeb0123_rxd_int_delay_vmereg  =  dcfeb_me11ab_interstage_adr;
+const int cfeb0123_rxd_int_delay_bitlo   =  8;
+const int cfeb0123_rxd_int_delay_bithi   =  11;
+const int cfeb0123_rxd_int_delay_default =  0; 
 //
 //
 //---------------------------------------------------------------------

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
@@ -338,6 +338,9 @@ static const unsigned long int  badbits601_adr          = 0x000164;  //ADR_V6_CF
 static const unsigned long int  badbits623_adr          = 0x000166;  //ADR_V6_CFEB6_BADBITS_LY23
 static const unsigned long int  badbits645_adr          = 0x000168;  //ADR_V6_CFEB6_BADBITS_LY45
 
+static const unsigned long int  phaser_cfeb5_rxd_adr	= 0x00016A;  
+static const unsigned long int  phaser_cfeb6_rxd_adr    = 0x00016C;
+
 static const unsigned long int  phaser_cfeb456_rxd_adr	= 0x00016A;  
 static const unsigned long int  phaser_cfeb0123_rxd_adr = 0x00016C;
 
@@ -2389,14 +2392,14 @@ const int cfeb4_rx_posneg_default       =  0;
 //--------------------------------------------------------------
 //[0X16A] = ADR_PHASER7:  values in the xml file for cfeb5_rx
 //--------------------------------------------------------------
-const int cfeb5_rx_clock_delay_vmereg   =  phaser_cfeb456_rxd_adr; // for compatibility, will be removed
+const int cfeb5_rx_clock_delay_vmereg   =  phaser_cfeb5_rxd_adr; // for compatibility, will be removed
 const int cfeb5_rx_clock_delay_default  =  3;                   //default value in nanoseconds (not the VME register values) 
 const int cfeb5_rx_posneg_default       =  0; 
 //
 //--------------------------------------------------------------
 //[0X16C] = ADR_PHASER8:  values in the xml file for cfeb6_rx
 //--------------------------------------------------------------
-const int cfeb6_rx_clock_delay_vmereg   =  phaser_cfeb456_rxd_adr; // for compatibility, will be removed
+const int cfeb6_rx_clock_delay_vmereg   =  phaser_cfeb6_rxd_adr; // for compatibility, will be removed
 const int cfeb6_rx_clock_delay_default  =  3;                   //default value in nanoseconds (not the VME register values) 
 const int cfeb6_rx_posneg_default       =  0; 
 //
@@ -2444,11 +2447,21 @@ const int cfeb4_rxd_int_delay_vmereg  =  cfeb4_6_interstage_adr;
 const int cfeb4_rxd_int_delay_bitlo   =  0;
 const int cfeb4_rxd_int_delay_bithi   =  3;
 const int cfeb4_rxd_int_delay_default =  0; 
-//! thse were called cfeb5_* and cfeb6_* before, these are grouped for me11
+//
+const int cfeb5_rxd_int_delay_vmereg  = cfeb4_6_interstage_adr;
+const int cfeb5_rxd_int_delay_bitlo   =  4;
+const int cfeb5_rxd_int_delay_bithi   =  7;
+const int cfeb5_rxd_int_delay_default =  0; 
+//
 const int cfeb456_rxd_int_delay_vmereg  =  dcfeb_me11ab_interstage_adr;
 const int cfeb456_rxd_int_delay_bitlo   =  4;
 const int cfeb456_rxd_int_delay_bithi   =  7;
 const int cfeb456_rxd_int_delay_default =  0; 
+//
+const int cfeb6_rxd_int_delay_vmereg  =  cfeb4_6_interstage_adr;
+const int cfeb6_rxd_int_delay_bitlo   =  8;
+const int cfeb6_rxd_int_delay_bithi   =  11;
+const int cfeb6_rxd_int_delay_default =  0; 
 //
 const int cfeb0123_rxd_int_delay_vmereg  =  dcfeb_me11ab_interstage_adr;
 const int cfeb0123_rxd_int_delay_bitlo   =  8;

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -559,7 +559,7 @@ namespace emu {
   namespace pc {
 
 
-    TMB::TMB(Crate * theCrate, Chamber * theChamber, int slot, int hardware_version) :
+  TMB::TMB(Crate * theCrate, Chamber * theChamber, int slot, int hardware_version) :
   VMEModule(theCrate, slot),
   EMUjtag(this),
   EmuLogger(),
@@ -2591,10 +2591,12 @@ void TMB::DisableCLCTInputs(){
   tmb_vme(VME_WRITE,cfeb_inj_adr,sndbuf,rcvbuf,NOW);
   //
   if (hardware_version_>=2){
-    tmb_vme(VME_READ,dcfeb_inj_seq_trig_adr,sndbuf,rcvbuf,NOW);
+    unsigned value_to_write = (sndbuf[1]&0xff) | (sndbuf[0]&0xff)<<8;
+    tmb_vme_new(VME_READ,dcfeb_inj_seq_trig_adr,value_to_write,rcvbuf,NOW);
     sndbuf[0] = (rcvbuf[0]&0xff);
     sndbuf[1] = (rcvbuf[1]&0xfc) ; //why are the bit fields hardcoded?
-    tmb_vme(VME_WRITE,dcfeb_inj_seq_trig_adr,sndbuf,rcvbuf,NOW);
+    value_to_write = (sndbuf[1]&0xff) | (sndbuf[0]&0xff)<<8;
+    tmb_vme_new(VME_WRITE,dcfeb_inj_seq_trig_adr,value_to_write,rcvbuf,NOW);
   }
 }
 //
@@ -2648,11 +2650,12 @@ void TMB::EnableCLCTInputs(int CLCTInputs){
 
    if (hardware_version_ >= 2){
      int CLCTInputs56 = ((CLCTInputs>>5) & 0x3);
-     adr = dcfeb_inj_seq_trig_adr;
-     tmb_vme(VME_READ,adr,sndbuf,rcvbuf,NOW);
-     rd_data   = ((rcvbuf[0]&0xff) << 8) | (rcvbuf[1]&0xff) ;
-     sndbuf[0] = rcvbuf[0];
-     sndbuf[1] = (rcvbuf[1] & 0xfc) | CLCTInputs56 ;
+     unsigned value_to_write = (sndbuf[1]&0xff) | (sndbuf[0]&0xff)<<8;
+     tmb_vme_new(VME_READ,dcfeb_inj_seq_trig_adr,value_to_write,rcvbuf,NOW);
+     sndbuf[0] = (rcvbuf[0]&0xff);
+     sndbuf[1] = (rcvbuf[1]&0xfc) | CLCTInputs56 ; //why are the bit fields hardcoded?                                                                                                                                                                     
+     value_to_write = (sndbuf[1]&0xff) | (sndbuf[0]&0xff)<<8;
+     tmb_vme_new(VME_WRITE,dcfeb_inj_seq_trig_adr,value_to_write,rcvbuf,NOW);
    }
 //
 }
@@ -5354,6 +5357,7 @@ void TMB::ReadDDDStateMachine() {
 void TMB::DefineTMBConfigurationRegisters_(){ 
   //
   TMBConfigurationRegister.clear();
+
   //
   // Registers used for TMB configuration....
   //
@@ -5415,11 +5419,12 @@ void TMB::DefineTMBConfigurationRegisters_(){
   TMBConfigurationRegister.push_back(phaser_cfeb2_rxd_adr);  //0x116 digital phase shifter: cfeb2_rx
   TMBConfigurationRegister.push_back(phaser_cfeb3_rxd_adr);  //0x118 digital phase shifter: cfeb3_rx
   TMBConfigurationRegister.push_back(phaser_cfeb4_rxd_adr);  //0x11A digital phase shifter: cfeb4_rx
-  TMBConfigurationRegister.push_back(phaser_cfeb456_rxd_adr);  //0x16A digital phase shifter: cfeb456_rx; can serve for #5 for bw compatibility
-  TMBConfigurationRegister.push_back(phaser_cfeb0123_rxd_adr); //0x16C digital phase shifter: cfeb0123_rx; can serve for #6 for bw compatibility
-  if (GetHardwareVersion() < 2){
-    TMBConfigurationRegister.push_back(cfeb0_3_interstage_adr);//0x11C CFEB to TMB data delay: cfeb[0-3]
+  if (GetHardwareVersion() >= 2){
+    TMBConfigurationRegister.push_back(phaser_cfeb5_rxd_adr);  //0x16A digital phase shifter: cfeb5_rx;
+    TMBConfigurationRegister.push_back(phaser_cfeb6_rxd_adr); //0x16C digital phase shifter: cfeb6_rx;
   }
+
+  TMBConfigurationRegister.push_back(cfeb0_3_interstage_adr);//0x11C CFEB to TMB data delay: cfeb[0-3]
   TMBConfigurationRegister.push_back(cfeb4_6_interstage_adr);//0x11E CFEB to TMB data delay: cfeb[4-6]
   //
   // hot channel masks:
@@ -5870,45 +5875,63 @@ void TMB::SetTMBRegisterDefaults() {
   //--------------------------------------------------------------
   //[0X112] = ADR_PHASER2:  values in the xml file for cfeb0_rx
   //--------------------------------------------------------------
-  cfeb0_rx_clock_delay_ = cfeb0_rx_clock_delay_default;
-  cfeb0_rx_posneg_      = cfeb0_rx_posneg_default     ;
+  cfeb0_rx_clock_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rx_clock_delay_default : cfeb0_rx_clock_delay_default;
+  cfeb0_rx_posneg_      = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rx_posneg_default : cfeb0_rx_posneg_default     ;
   //
   //--------------------------------------------------------------
   //[0X114] = ADR_PHASER3:  values in the xml file for cfeb1_rx
   //--------------------------------------------------------------
-  cfeb1_rx_clock_delay_ = cfeb1_rx_clock_delay_default;
-  cfeb1_rx_posneg_      = cfeb1_rx_posneg_default     ;
+  cfeb1_rx_clock_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rx_clock_delay_default : cfeb1_rx_clock_delay_default;
+  cfeb1_rx_posneg_      = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rx_posneg_default : cfeb1_rx_posneg_default     ;
   //
   //--------------------------------------------------------------
   //[0X116] = ADR_PHASER4:  values in the xml file for cfeb2_rx
   //--------------------------------------------------------------
-  cfeb2_rx_clock_delay_ = cfeb2_rx_clock_delay_default;
-  cfeb2_rx_posneg_      = cfeb2_rx_posneg_default     ;
+  cfeb2_rx_clock_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rx_clock_delay_default : cfeb2_rx_clock_delay_default;
+  cfeb2_rx_posneg_      = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rx_posneg_default : cfeb2_rx_posneg_default     ;
   //
   //--------------------------------------------------------------
   //[0X118] = ADR_PHASER5:  values in the xml file for cfeb3_rx
   //--------------------------------------------------------------
-  cfeb3_rx_clock_delay_ = cfeb3_rx_clock_delay_default;
-  cfeb3_rx_posneg_      = cfeb3_rx_posneg_default     ;
+  cfeb3_rx_clock_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rx_clock_delay_default : cfeb3_rx_clock_delay_default;
+  cfeb3_rx_posneg_      = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rx_posneg_default : cfeb3_rx_posneg_default     ;
   //
   //--------------------------------------------------------------
   //[0X11A] = ADR_PHASER6:  values in the xml file for cfeb4_rx
   //--------------------------------------------------------------
-  cfeb4_rx_clock_delay_ = cfeb4_rx_clock_delay_default;
-  cfeb4_rx_posneg_      = cfeb4_rx_posneg_default     ;
+  cfeb4_rx_clock_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rx_clock_delay_default : cfeb4_rx_clock_delay_default;
+  cfeb4_rx_posneg_      = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rx_posneg_default : cfeb4_rx_posneg_default     ;
+  //
+  //--------------------------------------------------------------
+  //[0X16A] = ADR_PHASER7:  values in the xml file for cfeb5_rx or cfeb456
+  //--------------------------------------------------------------
+  cfeb5_rx_clock_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rx_clock_delay_default : cfeb5_rx_clock_delay_default;
+  cfeb5_rx_posneg_      = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rx_posneg_default : cfeb5_rx_posneg_default     ;
+  cfeb456_rx_clock_delay_ = cfeb456_rx_clock_delay_default;
+  cfeb456_rx_posneg_ = cfeb456_rx_posneg_default; 
+  //
+  //--------------------------------------------------------------
+  //[0X16C] = ADR_PHASER8:  values in the xml file for cfeb6_rx or cfeb0123
+  //--------------------------------------------------------------
+  cfeb6_rx_clock_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rx_clock_delay_default : cfeb5_rx_clock_delay_default;
+  cfeb6_rx_posneg_      = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rx_posneg_default : cfeb6_rx_posneg_default     ;
+  cfeb0123_rx_clock_delay_ = cfeb0123_rx_clock_delay_default;
+  cfeb0123_rx_posneg_ = cfeb0123_rx_posneg_default; 
   //
   //--------------------------------------------------------------
   // 0X11C = ADR_DELAY0_INT:  CFEB to TMB "interstage" delays
   //--------------------------------------------------------------
-  cfeb0_rxd_int_delay_ = hardware_version_>=2 ? cfeb0123_rxd_int_delay_default : cfeb0_rxd_int_delay_default;
-  cfeb1_rxd_int_delay_ = hardware_version_>=2 ? cfeb0123_rxd_int_delay_default : cfeb1_rxd_int_delay_default;
-  cfeb2_rxd_int_delay_ = hardware_version_>=2 ? cfeb0123_rxd_int_delay_default : cfeb2_rxd_int_delay_default;
-  cfeb3_rxd_int_delay_ = hardware_version_>=2 ? cfeb0123_rxd_int_delay_default : cfeb3_rxd_int_delay_default;
+  cfeb0_rxd_int_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rxd_int_delay_default : cfeb0_rxd_int_delay_default;
+  cfeb1_rxd_int_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rxd_int_delay_default : cfeb1_rxd_int_delay_default;
+  cfeb2_rxd_int_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rxd_int_delay_default : cfeb2_rxd_int_delay_default;
+  cfeb3_rxd_int_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb0123_rxd_int_delay_default : cfeb3_rxd_int_delay_default;
   //
   //--------------------------------------------------------------
   // 0X11E = ADR_DELAY1_INT:  CFEB to TMB "interstage" delays
   //--------------------------------------------------------------
-  cfeb4_rxd_int_delay_ = hardware_version_>=2 ? cfeb456_rxd_int_delay_default : cfeb4_rxd_int_delay_default;
+  cfeb4_rxd_int_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rxd_int_delay_default : cfeb4_rxd_int_delay_default;
+  cfeb5_rxd_int_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rxd_int_delay_default : cfeb5_rxd_int_delay_default;
+  cfeb6_rxd_int_delay_ = HasGroupedME11ABCFEBRxValues() == 1 ? cfeb456_rxd_int_delay_default : cfeb6_rxd_int_delay_default;
   cfeb456_rxd_int_delay_ = cfeb456_rxd_int_delay_default;
   cfeb456_rxd_int_delay_ = cfeb456_rxd_int_delay_default;
   //
@@ -6669,6 +6692,8 @@ void TMB::DecodeTMBRegister_(unsigned long int address, int data) {
 	      address == phaser_cfeb2_rxd_adr ||
 	      address == phaser_cfeb3_rxd_adr ||
 	      address == phaser_cfeb4_rxd_adr || 
+	      address == phaser_cfeb5_rxd_adr || 
+	      address == phaser_cfeb6_rxd_adr || 
 	      address == phaser_cfeb456_rxd_adr ||
 	      address == phaser_cfeb0123_rxd_adr) {    
     //---------------------------------------------------------------------
@@ -6701,7 +6726,11 @@ void TMB::DecodeTMBRegister_(unsigned long int address, int data) {
     // 0X11E = ADR_DELAY1_INT:  CFEB to TMB "interstage" delays
     //---------------------------------------------------------------------
     read_cfeb4_rxd_int_delay_  = ExtractValueFromData(data,cfeb4_rxd_int_delay_bitlo,cfeb4_rxd_int_delay_bithi);    
-    if (GetHardwareVersion() == 2) {
+    if (HasGroupedME11ABCFEBRxValues() == 0){//ungrouped ME11
+      read_cfeb5_rxd_int_delay_  = ExtractValueFromData(data,cfeb5_rxd_int_delay_bitlo,cfeb5_rxd_int_delay_bithi);    
+      read_cfeb6_rxd_int_delay_  = ExtractValueFromData(data,cfeb6_rxd_int_delay_bitlo,cfeb6_rxd_int_delay_bithi);    
+    }
+    if (HasGroupedME11ABCFEBRxValues() == 1) {
       read_cfeb0123_rxd_int_delay_  = ExtractValueFromData(data,cfeb0123_rxd_int_delay_bitlo,cfeb0123_rxd_int_delay_bithi);    
       read_cfeb456_rxd_int_delay_   = ExtractValueFromData(data,cfeb456_rxd_int_delay_bitlo,cfeb456_rxd_int_delay_bithi);    
     }
@@ -7666,6 +7695,7 @@ void TMB::PrintTMBRegister(unsigned long int address) {
     //--------------------------------------------------------------
     //[0X112] = ADR_PHASER2:  CFEB0 -> TMB communication clock delay
     //--------------------------------------------------------------
+    if (HasGroupedME11ABCFEBRxValues() == 1) (*MyOutput_) << " ->CFEB0 to TMB communication clock IGNORED IN THIS VERSION:" << std::endl;
     (*MyOutput_) << " ->CFEB0 to TMB communication clock delay:" << std::endl;
     (*MyOutput_) << "    CFEB0 rx clock delay    = " << std::dec << read_cfeb0_rx_clock_delay_ << std::endl;
     (*MyOutput_) << "    CFEB0 posneg    = " << std::dec << read_cfeb0_rx_posneg_ << std::endl;
@@ -7674,6 +7704,7 @@ void TMB::PrintTMBRegister(unsigned long int address) {
     //--------------------------------------------------------------
     //[0X114] = ADR_PHASER3:  CFEB1 -> TMB communication clock delay
     //--------------------------------------------------------------
+    if (HasGroupedME11ABCFEBRxValues() == 1) (*MyOutput_) << " ->CFEB1 to TMB communication clock IGNORED IN THIS VERSION:" << std::endl;
     (*MyOutput_) << " ->CFEB1 to TMB communication clock delay:" << std::endl;
     (*MyOutput_) << "    CFEB1 rx clock delay    = " << std::dec << read_cfeb1_rx_clock_delay_ << std::endl;
     (*MyOutput_) << "    CFEB1 posneg    = " << std::dec << read_cfeb1_rx_posneg_ << std::endl;
@@ -7682,6 +7713,7 @@ void TMB::PrintTMBRegister(unsigned long int address) {
     //--------------------------------------------------------------
     //[0X116] = ADR_PHASER4:  CFEB2 -> TMB communication clock delay
     //--------------------------------------------------------------
+    if (HasGroupedME11ABCFEBRxValues() == 1) (*MyOutput_) << " ->CFEB2 to TMB communication clock IGNORED IN THIS VERSION:" << std::endl;
     (*MyOutput_) << " ->CFEB2 to TMB communication clock delay:" << std::endl;
     (*MyOutput_) << "    CFEB2 rx clock delay    = " << std::dec << read_cfeb2_rx_clock_delay_ << std::endl;
     (*MyOutput_) << "    CFEB2 posneg    = " << std::dec << read_cfeb2_rx_posneg_ << std::endl;
@@ -7690,6 +7722,7 @@ void TMB::PrintTMBRegister(unsigned long int address) {
     //--------------------------------------------------------------
     //[0X118] = ADR_PHASER5:  CFEB3 -> TMB communication clock delay
     //--------------------------------------------------------------
+    if (HasGroupedME11ABCFEBRxValues() == 1) (*MyOutput_) << " ->CFEB3 to TMB communication clock IGNORED IN THIS VERSION:" << std::endl;
     (*MyOutput_) << " ->CFEB3 to TMB communication clock delay:" << std::endl;
     (*MyOutput_) << "    CFEB3 rx clock delay    = " << std::dec << read_cfeb3_rx_clock_delay_ << std::endl;
     (*MyOutput_) << "    CFEB3 posneg    = " << std::dec << read_cfeb3_rx_posneg_ << std::endl;
@@ -7698,6 +7731,7 @@ void TMB::PrintTMBRegister(unsigned long int address) {
     //--------------------------------------------------------------
     //[0X11A] = ADR_PHASER6:  CFEB4 -> TMB communication clock delay
     //--------------------------------------------------------------
+    if (HasGroupedME11ABCFEBRxValues() == 1) (*MyOutput_) << " ->CFEB4 to TMB communication clock IGNORED IN THIS VERSION:" << std::endl;
     (*MyOutput_) << " ->CFEB4 to TMB communication clock delay:" << std::endl;
     (*MyOutput_) << "    CFEB4 rx clock delay    = " << std::dec << read_cfeb4_rx_clock_delay_ << std::endl;
     (*MyOutput_) << "    CFEB4 posneg    = " << std::dec << read_cfeb4_rx_posneg_ << std::endl;
@@ -7706,30 +7740,42 @@ void TMB::PrintTMBRegister(unsigned long int address) {
     //--------------------------------------------------------------
     //[0X16A] = ADR_PHASER7:  CFEB456 -> TMB communication clock delay
     //--------------------------------------------------------------
-    (*MyOutput_) << " ->CFEB456 to TMB communication clock delay:" << std::endl;
-    (*MyOutput_) << "    CFEB456 rx clock delay    = " << std::dec << read_cfeb456_rx_clock_delay_ << std::endl;
-    (*MyOutput_) << "    CFEB456 posneg    = " << std::dec << read_cfeb456_rx_posneg_ << std::endl;
-    //
+    if (HasGroupedME11ABCFEBRxValues() == 1){
+      (*MyOutput_) << " ->CFEB456 to TMB communication clock delay:" << std::endl;
+      (*MyOutput_) << "    CFEB456 rx clock delay    = " << std::dec << read_cfeb456_rx_clock_delay_ << std::endl;
+      (*MyOutput_) << "    CFEB456 posneg    = " << std::dec << read_cfeb456_rx_posneg_ << std::endl;
+    } else {
+      (*MyOutput_) << " ->CFEB5 to TMB communication clock delay:" << std::endl;
+      (*MyOutput_) << "    CFEB5 rx clock delay    = " << std::dec << read_cfeb5_rx_clock_delay_ << std::endl;
+      (*MyOutput_) << "    CFEB5 posneg    = " << std::dec << read_cfeb5_rx_posneg_ << std::endl;
+    }
+      //
   } else if ( address == phaser_cfeb0123_rxd_adr ) {
     //--------------------------------------------------------------
     //[0X16C] = ADR_PHASER8:  CFEB0123 -> TMB communication clock delay
     //--------------------------------------------------------------
-    (*MyOutput_) << " ->CFEB0123 to TMB communication clock delay:" << std::endl;
-    (*MyOutput_) << "    CFEB0123 rx clock delay    = " << std::dec << read_cfeb0123_rx_clock_delay_ << std::endl;
-    (*MyOutput_) << "    CFEB0123 posneg    = " << std::dec << read_cfeb0123_rx_posneg_ << std::endl;	
+    if (HasGroupedME11ABCFEBRxValues() == 1){
+      (*MyOutput_) << " ->CFEB0123 to TMB communication clock delay:" << std::endl;
+      (*MyOutput_) << "    CFEB0123 rx clock delay    = " << std::dec << read_cfeb0123_rx_clock_delay_ << std::endl;
+      (*MyOutput_) << "    CFEB0123 posneg    = " << std::dec << read_cfeb0123_rx_posneg_ << std::endl;	
+    } else {
+      (*MyOutput_) << " ->CFEB6 to TMB communication clock delay:" << std::endl;
+      (*MyOutput_) << "    CFEB6 rx clock delay    = " << std::dec << read_cfeb6_rx_clock_delay_ << std::endl;
+      (*MyOutput_) << "    CFEB6 posneg    = " << std::dec << read_cfeb6_rx_posneg_ << std::endl;	
+    }
     //
   } else if ( address == cfeb0_3_interstage_adr ) {
     //--------------------------------------------------------------
     // 0X11C = ADR_DELAY0_INT:  CFEB to TMB "interstage" delays
     //--------------------------------------------------------------
-    if (GetHardwareVersion() <2){
+    if (HasGroupedME11ABCFEBRxValues() <= 0){
       (*MyOutput_) << " ->CFEB to TMB interstage delays:" << std::endl;
       (*MyOutput_) << "    CFEB0 receive interstage delay    = " << std::dec << read_cfeb0_rxd_int_delay_ << std::endl;
       (*MyOutput_) << "    CFEB1 receive interstage delay    = " << std::dec << read_cfeb1_rxd_int_delay_ << std::endl;
       (*MyOutput_) << "    CFEB2 receive interstage delay    = " << std::dec << read_cfeb2_rxd_int_delay_ << std::endl;
       (*MyOutput_) << "    CFEB3 receive interstage delay    = " << std::dec << read_cfeb3_rxd_int_delay_ << std::endl;
     } else {
-      (*MyOutput_) << " ->CFEB0-3 to TMB interstage delays do nothing for HW version "<<GetHardwareVersion() << std::endl;
+      (*MyOutput_) << " ->CFEB0-3 to TMB interstage delays IGNORED IN THIS VERSION " << std::endl;
     }
     //
   } else if ( address == cfeb4_6_interstage_adr ) {
@@ -7737,10 +7783,14 @@ void TMB::PrintTMBRegister(unsigned long int address) {
     // 0X11E = ADR_DELAY1_INT:  CFEB to TMB "interstage" delays
     //--------------------------------------------------------------
     (*MyOutput_) << " ->CFEB to TMB interstage delays:" << std::endl;
-    if (GetHardwareVersion() <2){
+    if (HasGroupedME11ABCFEBRxValues() <= 0){
       (*MyOutput_) << "    CFEB4 receive interstage delay    = " << std::dec << read_cfeb4_rxd_int_delay_ << std::endl;
     }
-    if (GetHardwareVersion() == 2) {
+    if (HasGroupedME11ABCFEBRxValues() == 0){
+      (*MyOutput_) << "    CFEB5 receive interstage delay    = " << std::dec << read_cfeb5_rxd_int_delay_ << std::endl;
+      (*MyOutput_) << "    CFEB6 receive interstage delay    = " << std::dec << read_cfeb6_rxd_int_delay_ << std::endl;
+    }
+    if (HasGroupedME11ABCFEBRxValues() == 1) {
       (*MyOutput_) << "    CFEB0123 receive interstage delay    = " << std::dec << read_cfeb0123_rxd_int_delay_ << std::endl;
       (*MyOutput_) << "    CFEB456  receive interstage delay    = " << std::dec << read_cfeb456_rxd_int_delay_ << std::endl;
     }
@@ -7883,6 +7933,7 @@ void TMB::PrintFirmwareDate() {
   (*MyOutput_) << "-> TMB Firmware type   : " << std::hex << GetReadTmbFirmwareType()    << std::endl;
   (*MyOutput_) << "-> TMB Firmware version: " << std::hex << GetReadTmbFirmwareVersion() << std::endl;
   (*MyOutput_) << "-> TMB Firmware RevCode: " << std::hex << GetReadTmbFirmwareRevcode() << std::endl;
+  (*MyOutput_) << "... ... ...  " <<HasGroupedME11ABCFEBRxValues() <<  std::endl;
   //
   return;
 }
@@ -8410,17 +8461,25 @@ int TMB::FillTMBRegister(unsigned long int address) {
     //---------------------------------------------------------------------
     // 0X11C = ADR_DELAY0_INT:  CFEB to TMB "interstage" delays
     //---------------------------------------------------------------------
-    InsertValueIntoDataWord(cfeb0_rxd_int_delay_,cfeb0_rxd_int_delay_bithi,cfeb0_rxd_int_delay_bitlo,&data_word);
-    InsertValueIntoDataWord(cfeb1_rxd_int_delay_,cfeb1_rxd_int_delay_bithi,cfeb1_rxd_int_delay_bitlo,&data_word);
-    InsertValueIntoDataWord(cfeb2_rxd_int_delay_,cfeb2_rxd_int_delay_bithi,cfeb2_rxd_int_delay_bitlo,&data_word);
-    InsertValueIntoDataWord(cfeb3_rxd_int_delay_,cfeb3_rxd_int_delay_bithi,cfeb3_rxd_int_delay_bitlo,&data_word);
+    if (HasGroupedME11ABCFEBRxValues() <= 0) {
+      InsertValueIntoDataWord(cfeb0_rxd_int_delay_,cfeb0_rxd_int_delay_bithi,cfeb0_rxd_int_delay_bitlo,&data_word);
+      InsertValueIntoDataWord(cfeb1_rxd_int_delay_,cfeb1_rxd_int_delay_bithi,cfeb1_rxd_int_delay_bitlo,&data_word);
+      InsertValueIntoDataWord(cfeb2_rxd_int_delay_,cfeb2_rxd_int_delay_bithi,cfeb2_rxd_int_delay_bitlo,&data_word);
+      InsertValueIntoDataWord(cfeb3_rxd_int_delay_,cfeb3_rxd_int_delay_bithi,cfeb3_rxd_int_delay_bitlo,&data_word);
+    }
     //
   } else if ( address == cfeb4_6_interstage_adr ) {    
     //---------------------------------------------------------------------
     // 0X11E = ADR_DELAY1_INT:  CFEB to TMB "interstage" delays
     //---------------------------------------------------------------------
-    InsertValueIntoDataWord(cfeb4_rxd_int_delay_,cfeb4_rxd_int_delay_bithi,cfeb4_rxd_int_delay_bitlo,&data_word);
-    if (GetHardwareVersion() == 2) {
+    if (HasGroupedME11ABCFEBRxValues() <= 0) {
+      InsertValueIntoDataWord(cfeb4_rxd_int_delay_,cfeb4_rxd_int_delay_bithi,cfeb4_rxd_int_delay_bitlo,&data_word);
+    }
+    if (HasGroupedME11ABCFEBRxValues()  == 0 ) {
+      InsertValueIntoDataWord(cfeb5_rxd_int_delay_,cfeb5_rxd_int_delay_bithi,cfeb5_rxd_int_delay_bitlo,&data_word);
+      InsertValueIntoDataWord(cfeb6_rxd_int_delay_,cfeb6_rxd_int_delay_bithi,cfeb6_rxd_int_delay_bitlo,&data_word);
+    }
+    if (HasGroupedME11ABCFEBRxValues() == 1) {
       InsertValueIntoDataWord(cfeb0123_rxd_int_delay_,cfeb0123_rxd_int_delay_bithi,cfeb0123_rxd_int_delay_bitlo,&data_word);
       InsertValueIntoDataWord(cfeb456_rxd_int_delay_,cfeb456_rxd_int_delay_bithi,cfeb456_rxd_int_delay_bitlo,&data_word);
     }
@@ -8488,13 +8547,23 @@ int TMB::FillTMBRegister(unsigned long int address) {
     //---------------------------------------------------------------------
     //0X16A = ADR_PHASER7: digital phase shifter for cfeb456
     //---------------------------------------------------------------------
-    data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb456_rx_clock_delay_,cfeb456_rx_posneg_);
+    if (HasGroupedME11ABCFEBRxValues() == 0){//is at least ME11
+      data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb5_rx_clock_delay_,cfeb5_rx_posneg_);
+    }
+    if (HasGroupedME11ABCFEBRxValues() == 1){
+      data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb456_rx_clock_delay_,cfeb456_rx_posneg_);
+    }
     //
   } else if ( address == phaser_cfeb0123_rxd_adr ) {
     //---------------------------------------------------------------------
     //0X16C = ADR_PHASER8: digital phase shifter for cfeb0123
     //---------------------------------------------------------------------
-    data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb0123_rx_clock_delay_,cfeb0123_rx_posneg_);
+    if (HasGroupedME11ABCFEBRxValues() == 0){//is at least ME11
+      data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb6_rx_clock_delay_,cfeb6_rx_posneg_);
+    }
+    if (HasGroupedME11ABCFEBRxValues() == 1){
+      data_word = ConvertDigitalPhaseToVMERegisterValues_(cfeb0123_rx_clock_delay_,cfeb0123_rx_posneg_);
+    }
     //
   } else if ( address == dcfeb_inj_seq_trig_adr ) {
     //------------------------------------------------------------------
@@ -9054,45 +9123,78 @@ void TMB::CheckTMBConfiguration(int max_number_of_reads) {
     config_ok &= compareValues("TMB alct_tx_clock_delay",read_alct_tx_clock_delay_,alct_tx_clock_delay_, print_errors);
     config_ok &= compareValues("TMB alct_tx_posneg"     ,read_alct_tx_posneg_     ,alct_tx_posneg_     , print_errors); 
     //
-    //--------------------------------------------------------------
-    //[0X112] = ADR_PHASER2:  CFEB0 -> TMB communication
-    //--------------------------------------------------------------
-    // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
-    config_ok &= compareValues("TMB cfeb0delay"     ,read_cfeb0_rx_clock_delay_,cfeb0_rx_clock_delay_, print_errors);
-    config_ok &= compareValues("TMB cfeb0_rx_posneg",read_cfeb0_rx_posneg_     ,cfeb0_rx_posneg_     , print_errors);
-    //
-    //--------------------------------------------------------------
-    //[0X114] = ADR_PHASER3:  CFEB1 -> TMB communication
-    //--------------------------------------------------------------
-    // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
-    config_ok &= compareValues("TMB cfeb1delay"     ,read_cfeb1_rx_clock_delay_,cfeb1_rx_clock_delay_, print_errors);
-    config_ok &= compareValues("TMB cfeb1_rx_posneg",read_cfeb1_rx_posneg_     ,cfeb1_rx_posneg_     , print_errors);
-    //
-    //--------------------------------------------------------------
-    //[0X116] = ADR_PHASER4:  CFEB2 -> TMB communication
-    //--------------------------------------------------------------
-    // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
-    config_ok &= compareValues("TMB cfeb2delay"     ,read_cfeb2_rx_clock_delay_,cfeb2_rx_clock_delay_, print_errors);
-    config_ok &= compareValues("TMB cfeb2_rx_posneg",read_cfeb2_rx_posneg_     ,cfeb2_rx_posneg_     , print_errors);
-    //
-    //--------------------------------------------------------------
-    //[0X118] = ADR_PHASER5:  CFEB3 -> TMB communication
-    //--------------------------------------------------------------
-    // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
-    config_ok &= compareValues("TMB cfeb3delay"     ,read_cfeb3_rx_clock_delay_,cfeb3_rx_clock_delay_, print_errors);
-    config_ok &= compareValues("TMB cfeb3_rx_posneg",read_cfeb3_rx_posneg_     ,cfeb3_rx_posneg_     , print_errors);
-    //
-    //--------------------------------------------------------------
-    //[0X11A] = ADR_PHASER6:  CFEB4 -> TMB communication
-    //--------------------------------------------------------------
-    // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
-    config_ok &= compareValues("TMB cfeb4delay"     ,read_cfeb4_rx_clock_delay_,cfeb4_rx_clock_delay_, print_errors);
-    config_ok &= compareValues("TMB cfeb4_rx_posneg",read_cfeb4_rx_posneg_     ,cfeb4_rx_posneg_     , print_errors);
-    //
+    if (HasGroupedME11ABCFEBRxValues() <= 0){
+      //--------------------------------------------------------------
+      //[0X112] = ADR_PHASER2:  CFEB0 -> TMB communication
+      //--------------------------------------------------------------
+      // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
+      config_ok &= compareValues("TMB cfeb0delay"     ,read_cfeb0_rx_clock_delay_,cfeb0_rx_clock_delay_, print_errors);
+      config_ok &= compareValues("TMB cfeb0_rx_posneg",read_cfeb0_rx_posneg_     ,cfeb0_rx_posneg_     , print_errors);
+      //
+      //--------------------------------------------------------------
+      //[0X114] = ADR_PHASER3:  CFEB1 -> TMB communication
+      //--------------------------------------------------------------
+      // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
+      config_ok &= compareValues("TMB cfeb1delay"     ,read_cfeb1_rx_clock_delay_,cfeb1_rx_clock_delay_, print_errors);
+      config_ok &= compareValues("TMB cfeb1_rx_posneg",read_cfeb1_rx_posneg_     ,cfeb1_rx_posneg_     , print_errors);
+      //
+      //--------------------------------------------------------------
+      //[0X116] = ADR_PHASER4:  CFEB2 -> TMB communication
+      //--------------------------------------------------------------
+      // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
+      config_ok &= compareValues("TMB cfeb2delay"     ,read_cfeb2_rx_clock_delay_,cfeb2_rx_clock_delay_, print_errors);
+      config_ok &= compareValues("TMB cfeb2_rx_posneg",read_cfeb2_rx_posneg_     ,cfeb2_rx_posneg_     , print_errors);
+      //
+      //--------------------------------------------------------------
+      //[0X118] = ADR_PHASER5:  CFEB3 -> TMB communication
+      //--------------------------------------------------------------
+      // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
+      config_ok &= compareValues("TMB cfeb3delay"     ,read_cfeb3_rx_clock_delay_,cfeb3_rx_clock_delay_, print_errors);
+      config_ok &= compareValues("TMB cfeb3_rx_posneg",read_cfeb3_rx_posneg_     ,cfeb3_rx_posneg_     , print_errors);
+      //
+      //--------------------------------------------------------------
+      //[0X11A] = ADR_PHASER6:  CFEB4 -> TMB communication
+      //--------------------------------------------------------------
+      // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
+      config_ok &= compareValues("TMB cfeb4delay"     ,read_cfeb4_rx_clock_delay_,cfeb4_rx_clock_delay_, print_errors);
+      config_ok &= compareValues("TMB cfeb4_rx_posneg",read_cfeb4_rx_posneg_     ,cfeb4_rx_posneg_     , print_errors);
+      //
+      if (HasGroupedME11ABCFEBRxValues() == 0){ //ME11
+	//--------------------------------------------------------------
+	//[0X16A] = ADR_PHASER7:  CFEB5 -> TMB communication
+	//--------------------------------------------------------------
+	// the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
+	config_ok &= compareValues("TMB cfeb5delay"     ,read_cfeb5_rx_clock_delay_,cfeb5_rx_clock_delay_, print_errors);
+	config_ok &= compareValues("TMB cfeb5_rx_posneg",read_cfeb5_rx_posneg_     ,cfeb5_rx_posneg_     , print_errors);
+	//
+	//--------------------------------------------------------------
+	//[0X16C] = ADR_PHASER8:  CFEB6 -> TMB communication
+	//--------------------------------------------------------------
+	// the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database 
+	config_ok &= compareValues("TMB cfeb6delay"     ,read_cfeb6_rx_clock_delay_,cfeb6_rx_clock_delay_, print_errors);
+	config_ok &= compareValues("TMB cfeb6_rx_posneg",read_cfeb6_rx_posneg_     ,cfeb6_rx_posneg_     , print_errors);
+      }
+      //
+    }//end check if it has ungrouped CFEB RX
+    if (HasGroupedME11ABCFEBRxValues() == 1) {
+      //--------------------------------------------------------------
+      //[0X16A] = ADR_PHASER7:  CFEB456 -> TMB communication
+      //--------------------------------------------------------------
+      // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database
+      config_ok &= compareValues("TMB cfeb456delay"     ,read_cfeb456_rx_clock_delay_,cfeb456_rx_clock_delay_, print_errors);
+      config_ok &= compareValues("TMB cfeb456_rx_posneg",read_cfeb456_rx_posneg_     ,cfeb456_rx_posneg_     , print_errors);
+      //
+      //--------------------------------------------------------------
+      //[0X16C] = ADR_PHASER8:  CFEB0123 -> TMB communication
+      //--------------------------------------------------------------
+      // the lack of "rx" in the following label is legacy from the need for persistence of parameter names in the database
+      config_ok &= compareValues("TMB cfeb0123delay"     ,read_cfeb0123_rx_clock_delay_,cfeb0123_rx_clock_delay_, print_errors);
+      config_ok &= compareValues("TMB cfeb0123_rx_posneg",read_cfeb0123_rx_posneg_     ,cfeb0123_rx_posneg_     , print_errors);
+    }
     //--------------------------------------------------------------
     // 0X11C = ADR_DELAY0_INT:  CFEB to TMB "interstage" delays
     //--------------------------------------------------------------
-    if (GetHardwareVersion() < 2){
+    if (HasGroupedME11ABCFEBRxValues() <= 0){
       config_ok &= compareValues("TMB cfeb0_rxd_int_delay",read_cfeb0_rxd_int_delay_,cfeb0_rxd_int_delay_, print_errors);
       config_ok &= compareValues("TMB cfeb1_rxd_int_delay",read_cfeb1_rxd_int_delay_,cfeb1_rxd_int_delay_, print_errors);
       config_ok &= compareValues("TMB cfeb2_rxd_int_delay",read_cfeb2_rxd_int_delay_,cfeb2_rxd_int_delay_, print_errors);
@@ -9102,10 +9204,14 @@ void TMB::CheckTMBConfiguration(int max_number_of_reads) {
     //--------------------------------------------------------------
     // 0X11E = ADR_DELAY1_INT:  CFEB to TMB "interstage" delays
     //--------------------------------------------------------------
-    if (GetHardwareVersion() < 2){
+    if (HasGroupedME11ABCFEBRxValues() <=0 ){
       config_ok &= compareValues("TMB cfeb4_rxd_int_delay",read_cfeb4_rxd_int_delay_,cfeb4_rxd_int_delay_, print_errors);
     }
-    if (GetHardwareVersion() == 2) {
+    if (HasGroupedME11ABCFEBRxValues() ==0 ){
+      config_ok &= compareValues("TMB cfeb5_rxd_int_delay",read_cfeb5_rxd_int_delay_,cfeb5_rxd_int_delay_, print_errors);
+      config_ok &= compareValues("TMB cfeb6_rxd_int_delay",read_cfeb6_rxd_int_delay_,cfeb6_rxd_int_delay_, print_errors);
+    }
+    if (HasGroupedME11ABCFEBRxValues() == 1) {
       config_ok &= compareValues("TMB cfeb0123_rxd_int_delay",read_cfeb0123_rxd_int_delay_,cfeb0123_rxd_int_delay_, print_errors);
       config_ok &= compareValues("TMB cfeb456_rxd_int_delay", read_cfeb456_rxd_int_delay_,cfeb456_rxd_int_delay_, print_errors);
     }

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -6935,14 +6935,15 @@ void TMB::PrintTMBConfiguration() {
     unsigned long int VMEregister = TMBConfigurationRegister.at(index);
     //
     if (VMEregister != vme_usr_jtag_adr &&      // skip the user jtag register
-      VMEregister != hcm001_adr && VMEregister != hcm023_adr && VMEregister != hcm045_adr &&   //skip the hot channel
-      VMEregister != hcm101_adr && VMEregister != hcm123_adr && VMEregister != hcm145_adr &&   //mask registers...
-      VMEregister != hcm201_adr && VMEregister != hcm223_adr && VMEregister != hcm245_adr &&   //(print hot channel mask
-      VMEregister != hcm301_adr && VMEregister != hcm323_adr && VMEregister != hcm345_adr &&   //out in a different way)
-      VMEregister != hcm401_adr && VMEregister != hcm423_adr && VMEregister != hcm445_adr &&
-      (hardware_version_ >= 2 && (
-        VMEregister != hcm501_adr && VMEregister != hcm523_adr && VMEregister != hcm545_adr &&
-        VMEregister != hcm601_adr && VMEregister != hcm623_adr && VMEregister != hcm645_adr)) )
+	VMEregister != hcm001_adr && VMEregister != hcm023_adr && VMEregister != hcm045_adr &&   //skip the hot channel
+	VMEregister != hcm101_adr && VMEregister != hcm123_adr && VMEregister != hcm145_adr &&   //mask registers...
+	VMEregister != hcm201_adr && VMEregister != hcm223_adr && VMEregister != hcm245_adr &&   //(print hot channel mask
+	VMEregister != hcm301_adr && VMEregister != hcm323_adr && VMEregister != hcm345_adr &&   //out in a different way)
+	VMEregister != hcm401_adr && VMEregister != hcm423_adr && VMEregister != hcm445_adr &&
+	( ((hardware_version_ >= 2 && (
+				       VMEregister != hcm501_adr && VMEregister != hcm523_adr && VMEregister != hcm545_adr &&
+				       VMEregister != hcm601_adr && VMEregister != hcm623_adr && VMEregister != hcm645_adr)) )
+	  || hardware_version_ < 2) )
       PrintTMBRegister(VMEregister);
   }
   //


### PR DESCRIPTION
- cfeb{0123,456}_rxd_int_delay 
  - grouped ME11A and ME11B configuration parameters for HWv2 and a matching FW version
  - the set methods for individual CFEBs will crash for matching HW/FW version
  - GetCFEB_RxdIntDelay and corresponding GetRead_  methods for individual CFEBs are available and return a value corresponding to either individual CFEB or to the A/B group depending on the HW version
  - XML and other parsers are made aware

Asserts are currently in place in Set/Get methods that are not supposed to be called for a given HW version. I tested with configure read/write/check and with CFEB RX scan that the code is operational.
