### PR TITLE
Cfeb scan 5->7 leftover and Get/Set consistency

### DIFF
--- a/emuDCS/PeripheralApps/include/emu/pc/ChamberUtilities.h
+++ b/emuDCS/PeripheralApps/include/emu/pc/ChamberUtilities.h
@@ -477,7 +477,7 @@ public:
   inline void SetALCTWireScan(int Wire, int value)             { ALCTWireScan_[Wire] = value; }
   //
   int BestCCBDelaySetting ;
-  float CFEBMean[5];
+  //  float CFEBMean[5];
   int TMB_L1a_timing ;
   int Find_ALCT_L1a_delay;
   int ALCT_L1a_delay ;
@@ -559,7 +559,7 @@ private:
   float best_average_alct_dav_scope_;
   float best_average_cfeb_dav_scope_;
   //
-  int CFEBStripScan_[5][32];
+  int CFEBStripScan_[7][32];
   int ALCTWireScan_[112];
   //
   int AlctInClctMatchWindowHisto_[16];

--- a/emuDCS/PeripheralApps/src/common/CalibDAQ.cc
+++ b/emuDCS/PeripheralApps/src/common/CalibDAQ.cc
@@ -1365,7 +1365,7 @@ void CalibDAQ::FindL1aDelayComparator() {
       ::usleep(1000);
       //
       for (unsigned i=0; i<myTmbs.size(); i++) {
-	myTmbs[i]->EnableCLCTInputs(0x1f);
+	myTmbs[i]->EnableCLCTInputs(0x7f);
       }
       //
       usleep(1000);

--- a/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
+++ b/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
@@ -461,7 +461,7 @@ ChamberUtilities::ChamberUtilities(){
   TmbDavScopeAverageValue_   = -1;
   AlctDavScopeAverageValue_  = -1;
   //
-  for (int i=0;i<5;i++) 
+  for (int i=0;i<7;i++) 
     for (int j=0; j<32; j++) {
       CFEBStripScan_[i][j] = -1;
     }
@@ -1537,6 +1537,9 @@ void ChamberUtilities::Print_CLCT0() {
 void ChamberUtilities::Print_CFEB_Masks() {
   thisTMB->ReadRegister(seq_trig_en_adr);
   thisTMB->ReadRegister(cfeb_inj_adr);
+  if (thisTMB->GetHardwareVersion() >=2){
+    thisTMB->ReadRegister(dcfeb_inj_seq_trig_adr);
+  }
   thisTMB->GetReadEnableCLCTInject();
 }
     //

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -1125,16 +1125,9 @@ public:
   //0X42 = ADR_CFEB_INJ:  CFEB Injector Control:
   //----------------------------------------------------------------
   //!enableCLCTInputs = [0-31]... 5 bit mask, 1 bit per CFEB -> each bit [0,1] = [disable,enable] CFEB input
-  //!7 bits for OTMB
-  inline void SetEnableCLCTInputs(int enableCLCTInputs) { 
-    enableCLCTInputs_ = (enableCLCTInputs & 0x1f); 
-    if (GetHardwareVersion()>= 2) enableCLCTInputs_extend_ = ( (enableCLCTInputs >> 5) & 0x3);
-  } 
-  inline int  GetEnableCLCTInputs() { 
-    int val = enableCLCTInputs_ & 0x1f;
-    if (GetHardwareVersion()>= 2) val |= ((enableCLCTInputs_extend_ & 0x3) << 5);
-    return val;
-  }
+  //!7 bits for OTMB from 0X17A = ADR_V6_EXTEND
+  inline void SetEnableCLCTInputs(int enableCLCTInputs) { enableCLCTInputs_ = enableCLCTInputs; }
+  inline int  GetEnableCLCTInputs() { return enableCLCTInputs_; }
   inline int  GetReadEnableCLCTInputs() { 
     int val = ( read_enableCLCTInputs_ & 0x1f);
     if (GetHardwareVersion()>= 2) val |= ((read_enableCLCTInputs_extend_ & 0x3) <<5);
@@ -1143,15 +1136,8 @@ public:
   //
   //!cfeb_ram_sel = [0-31]... 5 bit mask, 1 bit per CFEB -> each bit [0,1] = [do not select,select] CFEB for RAM read/write
   //! 7 bits for OTMB
-  inline void SetSelectCLCTRAM(int cfeb_ram_sel) { 
-    cfeb_ram_sel_ = ( cfeb_ram_sel & 0x1f ); 
-    if (GetHardwareVersion()>= 2)    cfeb_ram_sel_extend_ = ( (cfeb_ram_sel >> 5) & 0x3 );
-  }        
-  inline int  GetSelectCLCTRAM() { 
-    int val = ( cfeb_ram_sel_ &  0x1f );
-    if (GetHardwareVersion()>= 2) val |= ((cfeb_ram_sel_extend_ & 0x3) << 5 );
-    return val;
-  }
+  inline void SetSelectCLCTRAM(int cfeb_ram_sel) { cfeb_ram_sel_ = cfeb_ram_sel; }
+  inline int  GetSelectCLCTRAM() { return cfeb_ram_sel_;}
   inline int  GetReadSelectCLCTRAM() { 
     int val = ( read_cfeb_ram_sel_ & 0x1f );
     if (GetHardwareVersion()>= 2) val |= ((read_cfeb_ram_sel_extend_ & 0x3) << 5 );
@@ -1160,15 +1146,8 @@ public:
   //
   //!cfeb_inj_en_sel = [0-31]... 5 bit mask, 1 bit per CFEB -> each bit [0,1] = [disable,enable] CFEB for injector trigger
   //! 7 bits for OTMB
-  inline void SetEnableCLCTInject(int cfeb_inj_en_sel) { 
-    cfeb_inj_en_sel_ = ( cfeb_inj_en_sel & 0x1f ); 
-    if (GetHardwareVersion()>= 2) cfeb_inj_en_sel_extend_ = ( ( cfeb_inj_en_sel >> 5 ) & 0x3 );
-  }  
-  inline int  GetEnableCLCTInject() { 
-    int val = ( cfeb_inj_en_sel_ & 0x1f);
-    if (GetHardwareVersion()>= 2) val |= ((cfeb_inj_en_sel_extend_ & 0x3) << 5 );
-    return val;
-  }
+  inline void SetEnableCLCTInject(int cfeb_inj_en_sel) { cfeb_inj_en_sel_ = cfeb_inj_en_sel; }
+  inline int  GetEnableCLCTInject() { return cfeb_inj_en_sel_; }
   inline int  GetReadEnableCLCTInject() { 
     int val = ( read_cfeb_inj_en_sel_ & 0x1f);
     if (GetHardwareVersion()>= 2) val |= ((read_cfeb_inj_en_sel_extend_ & 0x3) << 5 );
@@ -1255,11 +1234,13 @@ public:
   inline int  GetEnableAllCfebsActive() { return all_cfeb_active_; }
   //
   //!cfebs_enabled_ = [0-31] -> normally copied from 0x42.  See TMB documentation before setting these bits...
-  inline void SetCfebEnable(int cfebs_enabled) { 
-    cfebs_enabled_ = ( cfebs_enabled & 0x1f ); 
-    cfebs_enabled_extend_ = ( (cfebs_enabled >> 5)  & 0x3);
-  }
+  //!7 bits for OTMB to control 0X17A = ADR_V6_EXTEND
+  inline void SetCfebEnable(int cfebs_enabled) { cfebs_enabled_ = cfebs_enabled; }
   inline int  GetCfebEnable() { return cfebs_enabled_; }
+  inline int  GetReadCfebEnable() {
+    int val = read_cfebs_enabled_ & 0x1f;
+    if (GetHardwareVersion()>= 2) val |= ((read_cfebs_enabled_extend_ & 0x3) << 5);
+  }
   //
   //! value = 42, 68 = VME register which controls the CFEB mask.  See TMB documentation before setting this value.
   void Set_cfeb_enable_source(int value); 
@@ -2347,30 +2328,18 @@ public:
   //0X17A = ADR_V6_EXTEND: ADR_CFEB_INJ:  CFEB Injector Control; ADR_SEQ_TRIG_EN: 
   //----------------------------------------------------------------
   //!enableCLCTInputs for 5-6 = [0-3]... 2 bit mask, 1 bit per CFEB -> each bit [0,1] = [disable,enable] CFEB input
-  //! SetEnableCLCTInputsExtend shouldn't really be used by itself (see SetEnableCLCTInputs)
-  inline void SetEnableCLCTInputsExtend(int enableCLCTInputs) { enableCLCTInputs_extend_ = enableCLCTInputs; } 
-  inline int  GetEnableCLCTInputsExtend() { return enableCLCTInputs_extend_; }
-  inline int  GetReadEnableCLCTInputsExtend() { return read_enableCLCTInputs_extend_; }
+  //!register-reads only. Configuration is controlled by one value enableCLCTInputs_ and can be read in a fuse by GetReadEnableCLCTInputs()
   //
   //!cfeb_ram_sel for 5-6 = [0-3]... 2 bit mask, 1 bit per CFEB -> each bit [0,1] = [do not select,select] CFEB for RAM read/write
-  //!SetSelectCLCTRAMExtend shouldn't really be used by itself: preferred way is to set via SetSelectCLCTRAM
-  inline void SetSelectCLCTRAMExtend(int cfeb_ram_sel) { cfeb_ram_sel_extend_ = cfeb_ram_sel; }        
-  inline int  GetSelectCLCTRAMExtend() { return cfeb_ram_sel_extend_; }
-  inline int  GetReadSelectCLCTRAMExtend() { return read_cfeb_ram_sel_extend_; }
+  //!register-reads only. Configuration is controlled by one value cfeb_ram_sel_ and can be read in a fuse by GetReadSelectCLCTRAM()
   //
   //!cfeb_inj_en_sel for 5-6 = [0-3]... 2 bit mask, 1 bit per CFEB -> each bit [0,1] = [disable,enable] CFEB for injector trigger
-  //!SetEnableCLCTInjectExtend shouldn't really be used by itself: preferred way is to set via SetEnableCLCTInject
-  inline void SetEnableCLCTInjectExtend(int cfeb_inj_en_sel) { cfeb_inj_en_sel_extend_ = cfeb_inj_en_sel; }  
-  inline int  GetEnableCLCTInjectExtend() { return cfeb_inj_en_sel_extend_; }
-  inline int  GetReadEnableCLCTInjectExtend() { return read_cfeb_inj_en_sel_extend_; }
+  //!register-reads only. Configuration is controlled by one value cfeb_inj_en_sel_ and can be read in a fuse by GetReadEnableCLCTInject()
   //
   //!cfebs_enabled_extend for 5-6 = [0-3] -> normally copied from 0x42.  See TMB documentation before setting these bits...
-  //!SetCfebEnableExtend shouldn't really be used by itself: preferred way is to set via SetCfebEnable
-  inline void SetCfebEnableExtend(int cfebs_enabled) { cfebs_enabled_extend_ = cfebs_enabled; }
-  inline int  GetCfebEnableExtend() { return cfebs_enabled_extend_; }
-  inline int  GetReadCfebEnableExtend() { return read_cfebs_enabled_extend_; }
+  //!register-reads only. Configuration is controlled by one value cfebs_enabled_ and can be read in a fuse by GetReadCfebEnable()
   //
-  //!cfebs_enabled_extend_readback  = should be the same as cfebs_enabled_extend for 5-6 
+  //!cfebs_enabled_extend_readback  = should be the same as GetReadCfebEnable for bits 5-6 
   inline int  GetReadCfebEnableExtendReadback() { return read_cfebs_enabled_extend_readback_; }
   //
   //
@@ -3805,16 +3774,10 @@ private:
   //------------------------------------------------------------------
   //0X17A = ADR_V6_EXTEND: extensions of ADR_CFEB_INJ and ADR_SEQ_TRIG_EN 
   //------------------------------------------------------------------
-  //
-  int enableCLCTInputs_extend_;
-  int cfeb_ram_sel_extend_;
-  int cfeb_inj_en_sel_extend_;
-  //
+  //! only register reads are kept ; settings are from the common place
   int read_enableCLCTInputs_extend_;
   int read_cfeb_ram_sel_extend_;
   int read_cfeb_inj_en_sel_extend_;
-  //
-  int cfebs_enabled_extend_;
   //
   int read_cfebs_enabled_extend_;
   int read_cfebs_enabled_extend_readback_;

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -1129,24 +1129,36 @@ public:
     enableCLCTInputs_ = (enableCLCTInputs & 0x1f); 
     enableCLCTInputs_extend_ = ( (enableCLCTInputs >> 5) & 0x3);
   } 
-  inline int  GetEnableCLCTInputs() { return enableCLCTInputs_; }
-  inline int  GetReadEnableCLCTInputs() { return read_enableCLCTInputs_; }
+  inline int  GetEnableCLCTInputs() { 
+    return (enableCLCTInputs_ & 0x1f) | ((enableCLCTInputs_extend_ & 0x3) << 5); 
+  }
+  inline int  GetReadEnableCLCTInputs() { 
+    return ( read_enableCLCTInputs_ & 0x1f) | ((read_enableCLCTInputs_extend_ & 0x3) <<5); 
+  }
   //
   //!cfeb_ram_sel = [0-31]... 5 bit mask, 1 bit per CFEB -> each bit [0,1] = [do not select,select] CFEB for RAM read/write
   inline void SetSelectCLCTRAM(int cfeb_ram_sel) { 
     cfeb_ram_sel_ = ( cfeb_ram_sel & 0x1f ); 
     cfeb_ram_sel_extend_ = ( (cfeb_ram_sel >> 5) & 0x3 );
   }        
-  inline int  GetSelectCLCTRAM() { return cfeb_ram_sel_; }
-  inline int  GetReadSelectCLCTRAM() { return read_cfeb_ram_sel_; }
+  inline int  GetSelectCLCTRAM() { 
+    return ( cfeb_ram_sel_ &  0x1f ) | ((cfeb_ram_sel_extend_ & 0x3) << 5 ) ; 
+  }
+  inline int  GetReadSelectCLCTRAM() { 
+    return (read_cfeb_ram_sel_ & 0x1f ) | ((read_cfeb_ram_sel_extend_ & 0x3) << 5 );
+  }
   //
   //!cfeb_inj_en_sel = [0-31]... 5 bit mask, 1 bit per CFEB -> each bit [0,1] = [disable,enable] CFEB for injector trigger
   inline void SetEnableCLCTInject(int cfeb_inj_en_sel) { 
     cfeb_inj_en_sel_ = ( cfeb_inj_en_sel & 0x1f ); 
     cfeb_inj_en_sel_extend_ = ( ( cfeb_inj_en_sel >> 5 ) & 0x3 );
   }  
-  inline int  GetEnableCLCTInject() { return cfeb_inj_en_sel_; }
-  inline int  GetReadEnableCLCTInject() { return read_cfeb_inj_en_sel_; }
+  inline int  GetEnableCLCTInject() { 
+    return ( cfeb_inj_en_sel_ 0x1f) | ((cfeb_inj_en_sel_extend_ & 0x3) << 5 ); 
+  }
+  inline int  GetReadEnableCLCTInject() { 
+    return ( read_cfeb_inj_en_sel_ & 0x1f) | ((read_cfeb_inj_en_sel_extend_ & 0x3) << 5 ); 
+  }
   //
   //!start_pattern_inj = 1 = start pattern injector
   inline void SetStartPatternInjector(int start_pattern_inj) { start_pattern_inj_ = start_pattern_inj; } 

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -1125,39 +1125,54 @@ public:
   //0X42 = ADR_CFEB_INJ:  CFEB Injector Control:
   //----------------------------------------------------------------
   //!enableCLCTInputs = [0-31]... 5 bit mask, 1 bit per CFEB -> each bit [0,1] = [disable,enable] CFEB input
+  //!7 bits for OTMB
   inline void SetEnableCLCTInputs(int enableCLCTInputs) { 
     enableCLCTInputs_ = (enableCLCTInputs & 0x1f); 
-    enableCLCTInputs_extend_ = ( (enableCLCTInputs >> 5) & 0x3);
+    if (GetHardwareVersion()>= 2) enableCLCTInputs_extend_ = ( (enableCLCTInputs >> 5) & 0x3);
   } 
   inline int  GetEnableCLCTInputs() { 
-    return (enableCLCTInputs_ & 0x1f) | ((enableCLCTInputs_extend_ & 0x3) << 5); 
+    int val = enableCLCTInputs_ & 0x1f;
+    if (GetHardwareVersion()>= 2) val |= ((enableCLCTInputs_extend_ & 0x3) << 5);
+    return val;
   }
   inline int  GetReadEnableCLCTInputs() { 
-    return ( read_enableCLCTInputs_ & 0x1f) | ((read_enableCLCTInputs_extend_ & 0x3) <<5); 
+    int val = ( read_enableCLCTInputs_ & 0x1f);
+    if (GetHardwareVersion()>= 2) val |= ((read_enableCLCTInputs_extend_ & 0x3) <<5);
+    return val;
   }
   //
   //!cfeb_ram_sel = [0-31]... 5 bit mask, 1 bit per CFEB -> each bit [0,1] = [do not select,select] CFEB for RAM read/write
+  //! 7 bits for OTMB
   inline void SetSelectCLCTRAM(int cfeb_ram_sel) { 
     cfeb_ram_sel_ = ( cfeb_ram_sel & 0x1f ); 
-    cfeb_ram_sel_extend_ = ( (cfeb_ram_sel >> 5) & 0x3 );
+    if (GetHardwareVersion()>= 2)    cfeb_ram_sel_extend_ = ( (cfeb_ram_sel >> 5) & 0x3 );
   }        
   inline int  GetSelectCLCTRAM() { 
-    return ( cfeb_ram_sel_ &  0x1f ) | ((cfeb_ram_sel_extend_ & 0x3) << 5 ) ; 
+    int val = ( cfeb_ram_sel_ &  0x1f );
+    if (GetHardwareVersion()>= 2) val |= ((cfeb_ram_sel_extend_ & 0x3) << 5 );
+    return val;
   }
   inline int  GetReadSelectCLCTRAM() { 
-    return (read_cfeb_ram_sel_ & 0x1f ) | ((read_cfeb_ram_sel_extend_ & 0x3) << 5 );
+    int val = ( read_cfeb_ram_sel_ & 0x1f );
+    if (GetHardwareVersion()>= 2) val |= ((read_cfeb_ram_sel_extend_ & 0x3) << 5 );
+    return val;
   }
   //
   //!cfeb_inj_en_sel = [0-31]... 5 bit mask, 1 bit per CFEB -> each bit [0,1] = [disable,enable] CFEB for injector trigger
+  //! 7 bits for OTMB
   inline void SetEnableCLCTInject(int cfeb_inj_en_sel) { 
     cfeb_inj_en_sel_ = ( cfeb_inj_en_sel & 0x1f ); 
-    cfeb_inj_en_sel_extend_ = ( ( cfeb_inj_en_sel >> 5 ) & 0x3 );
+    if (GetHardwareVersion()>= 2) cfeb_inj_en_sel_extend_ = ( ( cfeb_inj_en_sel >> 5 ) & 0x3 );
   }  
   inline int  GetEnableCLCTInject() { 
-    return ( cfeb_inj_en_sel_ 0x1f) | ((cfeb_inj_en_sel_extend_ & 0x3) << 5 ); 
+    int val = ( cfeb_inj_en_sel_ & 0x1f);
+    if (GetHardwareVersion()>= 2) val |= ((cfeb_inj_en_sel_extend_ & 0x3) << 5 );
+    return val;
   }
   inline int  GetReadEnableCLCTInject() { 
-    return ( read_cfeb_inj_en_sel_ & 0x1f) | ((read_cfeb_inj_en_sel_extend_ & 0x3) << 5 ); 
+    int val = ( read_cfeb_inj_en_sel_ & 0x1f);
+    if (GetHardwareVersion()>= 2) val |= ((read_cfeb_inj_en_sel_extend_ & 0x3) << 5 );
+    return val;
   }
   //
   //!start_pattern_inj = 1 = start pattern injector

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -1238,8 +1238,9 @@ public:
   inline void SetCfebEnable(int cfebs_enabled) { cfebs_enabled_ = cfebs_enabled; }
   inline int  GetCfebEnable() { return cfebs_enabled_; }
   inline int  GetReadCfebEnable() {
-    int val = read_cfebs_enabled_ & 0x1f;
+    int val = (read_cfebs_enabled_ & 0x1f);
     if (GetHardwareVersion()>= 2) val |= ((read_cfebs_enabled_extend_ & 0x3) << 5);
+    return val;
   }
   //
   //! value = 42, 68 = VME register which controls the CFEB mask.  See TMB documentation before setting this value.

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
@@ -980,17 +980,17 @@ const int alct_raw_msbs_bithi        = 14;
 const int enableCLCTInputs_vmereg   =  cfeb_inj_adr;
 const int enableCLCTInputs_bitlo    =  0;
 const int enableCLCTInputs_bithi    =  4;
-const int enableCLCTInputs_default  =0x1f;
+const int enableCLCTInputs_default  =0x7f; //this is the config default: high bits go to enableCLCTInputs_extend_vmereg
 //
 const int cfeb_ram_sel_vmereg       =  cfeb_inj_adr;
 const int cfeb_ram_sel_bitlo        =  5;
 const int cfeb_ram_sel_bithi        =  9;
-const int cfeb_ram_sel_default      =  0;
+const int cfeb_ram_sel_default      =  0; //this is the config default: high bits go to cfeb_ram_sel_extend_vmereg
 //
 const int cfeb_inj_en_sel_vmereg    =  cfeb_inj_adr;
 const int cfeb_inj_en_sel_bitlo     = 10;
 const int cfeb_inj_en_sel_bithi     = 14;
-const int cfeb_inj_en_sel_default   =0x1f;
+const int cfeb_inj_en_sel_default   =0x7f; //this is the config default: high bits go to cfeb_inj_en_sel_extend_vmereg
 //
 const int start_pattern_inj_vmereg  =  cfeb_inj_adr;
 const int start_pattern_inj_bitlo   = 15;
@@ -1157,7 +1157,7 @@ const int all_cfeb_active_default    =  0;
 const int cfebs_enabled_vmereg       =  seq_trig_en_adr;
 const int cfebs_enabled_bitlo        = 10;
 const int cfebs_enabled_bithi        = 14;
-const int cfebs_enabled_default      =0x1f;
+const int cfebs_enabled_default      =0x7f; //this is the config default: high bits go to cfebs_enabled_extend_vmereg
 //
 const int cfeb_enable_source_vmereg  =  seq_trig_en_adr;
 const int cfeb_enable_source_bitlo   = 15;
@@ -2740,27 +2740,22 @@ const int gtx_rx_error_count_bithi     =  15;
 const int enableCLCTInputs_extend_vmereg             = dcfeb_inj_seq_trig_adr;
 const int enableCLCTInputs_extend_bitlo              =   0;
 const int enableCLCTInputs_extend_bithi              =   1;
-const int enableCLCTInputs_extend_default            = 0x3;
 //
 const int cfeb_ram_sel_extend_vmereg                 = dcfeb_inj_seq_trig_adr;
 const int cfeb_ram_sel_extend_bitlo                  =   2;
 const int cfeb_ram_sel_extend_bithi                  =   3;
-const int cfeb_ram_sel_extend_default                =   0;
 //
 const int cfeb_inj_en_sel_extend_vmereg              = dcfeb_inj_seq_trig_adr;
 const int cfeb_inj_en_sel_extend_bitlo               =   4;
 const int cfeb_inj_en_sel_extend_bithi               =   5;
-const int cfeb_inj_en_sel_extend_default             = 0x3;
 //     ADR_SEQ_TRIG_EN parts
 const int cfebs_enabled_extend_vmereg                = dcfeb_inj_seq_trig_adr;
 const int cfebs_enabled_extend_bitlo                 =   6;
 const int cfebs_enabled_extend_bithi                 =   7;
-const int cfebs_enabled_extend_default               = 0x3;
 //
 const int cfebs_enabled_extend_readback_vmereg       = dcfeb_inj_seq_trig_adr;
 const int cfebs_enabled_extend_readback_bitlo        =   8;
 const int cfebs_enabled_extend_readback_bithi        =   9;
-const int cfebs_enabled_extend_readback_default      = 0x3;
 
 //
 //////////////////////////////////////////////

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -5977,10 +5977,7 @@ void TMB::SetTMBRegisterDefaults() {
   //------------------------------------------------------------------
   //0X17A = ADR_V6_EXTEND: ADR_CFEB_INJ:  CFEB Injector Control; ADR_SEQ_TRIG_EN:
   //------------------------------------------------------------------
-  enableCLCTInputs_extend_           = enableCLCTInputs_extend_default ;
-  cfeb_ram_sel_extend_               = cfeb_ram_sel_extend_default     ;
-  cfeb_inj_en_sel_extend_            = cfeb_inj_en_sel_extend_default  ;
-  cfebs_enabled_extend_              = cfebs_enabled_extend_default     ;  
+  //defaults are pulled from the main parameter fields
 
   return;
 }
@@ -8113,9 +8110,9 @@ int TMB::FillTMBRegister(unsigned long int address) {
     //------------------------------------------------------------------
     //0X42 = ADR_CFEB_INJ:  CFEB Injector Control
     //------------------------------------------------------------------
-    InsertValueIntoDataWord(enableCLCTInputs_ ,enableCLCTInputs_bithi ,enableCLCTInputs_bitlo ,&data_word);
-    InsertValueIntoDataWord(cfeb_ram_sel_     ,cfeb_ram_sel_bithi     ,cfeb_ram_sel_bitlo     ,&data_word);
-    InsertValueIntoDataWord(cfeb_inj_en_sel_  ,cfeb_inj_en_sel_bithi  ,cfeb_inj_en_sel_bitlo  ,&data_word);
+    InsertValueIntoDataWord((enableCLCTInputs_&0x1f) ,enableCLCTInputs_bithi ,enableCLCTInputs_bitlo ,&data_word);
+    InsertValueIntoDataWord((cfeb_ram_sel_    &0x1f) ,cfeb_ram_sel_bithi     ,cfeb_ram_sel_bitlo     ,&data_word);
+    InsertValueIntoDataWord((cfeb_inj_en_sel_ &0x1f) ,cfeb_inj_en_sel_bithi  ,cfeb_inj_en_sel_bitlo  ,&data_word);
     InsertValueIntoDataWord(start_pattern_inj_,start_pattern_inj_bithi,start_pattern_inj_bitlo,&data_word);
     //
   } else if ( address == hcm001_adr || address == hcm023_adr || address == hcm045_adr ||
@@ -8148,18 +8145,18 @@ int TMB::FillTMBRegister(unsigned long int address) {
     //------------------------------------------------------------------
     //0X68 = ADR_SEQ_TRIG_EN:  Sequencer Trigger Source Enables
     //------------------------------------------------------------------
-    InsertValueIntoDataWord(clct_pat_trig_en_  ,clct_pat_trig_en_bithi  ,clct_pat_trig_en_bitlo  ,&data_word);
-    InsertValueIntoDataWord(alct_pat_trig_en_  ,alct_pat_trig_en_bithi  ,alct_pat_trig_en_bitlo  ,&data_word);
-    InsertValueIntoDataWord(match_pat_trig_en_ ,match_pat_trig_en_bithi ,match_pat_trig_en_bitlo ,&data_word);
-    InsertValueIntoDataWord(adb_ext_trig_en_   ,adb_ext_trig_en_bithi   ,adb_ext_trig_en_bitlo   ,&data_word);
-    InsertValueIntoDataWord(dmb_ext_trig_en_   ,dmb_ext_trig_en_bithi   ,dmb_ext_trig_en_bitlo   ,&data_word);
-    InsertValueIntoDataWord(clct_ext_trig_en_  ,clct_ext_trig_en_bithi  ,clct_ext_trig_en_bitlo  ,&data_word);
-    InsertValueIntoDataWord(alct_ext_trig_en_  ,alct_ext_trig_en_bithi  ,alct_ext_trig_en_bitlo  ,&data_word);
-    InsertValueIntoDataWord(vme_ext_trig_      ,vme_ext_trig_bithi      ,vme_ext_trig_bitlo      ,&data_word);
-    InsertValueIntoDataWord(ext_trig_inject_   ,ext_trig_inject_bithi   ,ext_trig_inject_bitlo   ,&data_word);
-    InsertValueIntoDataWord(all_cfeb_active_   ,all_cfeb_active_bithi   ,all_cfeb_active_bitlo   ,&data_word);
-    InsertValueIntoDataWord(cfebs_enabled_     ,cfebs_enabled_bithi     ,cfebs_enabled_bitlo     ,&data_word);
-    InsertValueIntoDataWord(cfeb_enable_source_,cfeb_enable_source_bithi,cfeb_enable_source_bitlo,&data_word);
+    InsertValueIntoDataWord(clct_pat_trig_en_    ,clct_pat_trig_en_bithi  ,clct_pat_trig_en_bitlo  ,&data_word);
+    InsertValueIntoDataWord(alct_pat_trig_en_    ,alct_pat_trig_en_bithi  ,alct_pat_trig_en_bitlo  ,&data_word);
+    InsertValueIntoDataWord(match_pat_trig_en_   ,match_pat_trig_en_bithi ,match_pat_trig_en_bitlo ,&data_word);
+    InsertValueIntoDataWord(adb_ext_trig_en_     ,adb_ext_trig_en_bithi   ,adb_ext_trig_en_bitlo   ,&data_word);
+    InsertValueIntoDataWord(dmb_ext_trig_en_     ,dmb_ext_trig_en_bithi   ,dmb_ext_trig_en_bitlo   ,&data_word);
+    InsertValueIntoDataWord(clct_ext_trig_en_    ,clct_ext_trig_en_bithi  ,clct_ext_trig_en_bitlo  ,&data_word);
+    InsertValueIntoDataWord(alct_ext_trig_en_    ,alct_ext_trig_en_bithi  ,alct_ext_trig_en_bitlo  ,&data_word);
+    InsertValueIntoDataWord(vme_ext_trig_        ,vme_ext_trig_bithi      ,vme_ext_trig_bitlo      ,&data_word);
+    InsertValueIntoDataWord(ext_trig_inject_     ,ext_trig_inject_bithi   ,ext_trig_inject_bitlo   ,&data_word);
+    InsertValueIntoDataWord(all_cfeb_active_     ,all_cfeb_active_bithi   ,all_cfeb_active_bitlo   ,&data_word);
+    InsertValueIntoDataWord((cfebs_enabled_&0x1f),cfebs_enabled_bithi     ,cfebs_enabled_bitlo     ,&data_word);
+    InsertValueIntoDataWord(cfeb_enable_source_  ,cfeb_enable_source_bithi,cfeb_enable_source_bitlo,&data_word);
     //    
   } else if ( address == seq_trig_dly0_adr ) {
     //------------------------------------------------------------------
@@ -8570,10 +8567,10 @@ int TMB::FillTMBRegister(unsigned long int address) {
     //------------------------------------------------------------------
     //0X17A = ADR_V6_EXTEND: ADR_CFEB_INJ:  CFEB Injector Control; ADR_SEQ_TRIG_EN: 
     //------------------------------------------------------------------
-    InsertValueIntoDataWord(enableCLCTInputs_extend_ ,enableCLCTInputs_extend_bithi ,enableCLCTInputs_extend_bitlo ,&data_word);
-    InsertValueIntoDataWord(cfeb_ram_sel_extend_     ,cfeb_ram_sel_extend_bithi     ,cfeb_ram_sel_extend_bitlo     ,&data_word);
-    InsertValueIntoDataWord(cfeb_inj_en_sel_extend_  ,cfeb_inj_en_sel_extend_bithi  ,cfeb_inj_en_sel_extend_bitlo  ,&data_word);
-    InsertValueIntoDataWord(cfebs_enabled_extend_    ,cfebs_enabled_extend_bithi    ,cfebs_enabled_extend_bitlo    ,&data_word);
+    InsertValueIntoDataWord(((enableCLCTInputs_>>5)&0x3) ,enableCLCTInputs_extend_bithi ,enableCLCTInputs_extend_bitlo ,&data_word);
+    InsertValueIntoDataWord(((cfeb_ram_sel_    >>5)&0x3) ,cfeb_ram_sel_extend_bithi     ,cfeb_ram_sel_extend_bitlo     ,&data_word);
+    InsertValueIntoDataWord(((cfeb_inj_en_sel_ >>5)&0x3) ,cfeb_inj_en_sel_extend_bithi  ,cfeb_inj_en_sel_extend_bitlo  ,&data_word);
+    InsertValueIntoDataWord(((cfebs_enabled_   >>5)&0x3) ,cfebs_enabled_extend_bithi    ,cfebs_enabled_extend_bitlo    ,&data_word);
     //
   } else {
     //
@@ -8770,14 +8767,11 @@ void TMB::CheckTMBConfiguration(int max_number_of_reads) {
     // If no  => expected value of address 0x68 = write value of address 0x68 
     //
     int cfebs_enabled_expected;
-    int cfebs_enabled_extend_expected;
     //
     if (GetCfebEnableSource() == 1) {
       cfebs_enabled_expected = enableCLCTInputs_;
-      cfebs_enabled_extend_expected = enableCLCTInputs_extend_;
     } else {
       cfebs_enabled_expected = cfebs_enabled_; 
-      cfebs_enabled_extend_expected = cfebs_enabled_extend_; 
     }
     //
     //-----------------------------------------------------------------
@@ -8875,10 +8869,10 @@ void TMB::CheckTMBConfiguration(int max_number_of_reads) {
     //------------------------------------------------------------------
     //0X42 = ADR_CFEB_INJ:  CFEB Injector Control
     //------------------------------------------------------------------
-    config_ok &= compareValues("TMB enableCLCTInputs_reg42"                         ,read_enableCLCTInputs_ ,enableCLCTInputs_ , print_errors);
-    config_ok &= compareValues("TMB Select CFEB n for RAM read/write (not in xml)"  ,read_cfeb_ram_sel_     ,cfeb_ram_sel_     , print_errors);
-    config_ok &= compareValues("TMB Enable CFEB n for injector trigger (not in xml)",read_cfeb_inj_en_sel_  ,cfeb_inj_en_sel_  , print_errors); 
-    config_ok &= compareValues("TMB Start CLCT pattern injector (not in xml)"       ,read_start_pattern_inj_,start_pattern_inj_, print_errors);
+    config_ok &= compareValues("TMB enableCLCTInputs_reg42(+17A)"                ,GetReadEnableCLCTInputs()     ,enableCLCTInputs_ , print_errors);
+    config_ok &= compareValues("TMB Select CFEB n for RAM read/write (not in xml)"  ,GetReadSelectCLCTRAM()     ,cfeb_ram_sel_     , print_errors);
+    config_ok &= compareValues("TMB Enable CFEB n for injector trigger (not in xml)",GetReadEnableCLCTInject()  ,cfeb_inj_en_sel_  , print_errors); 
+    config_ok &= compareValues("TMB Start CLCT pattern injector (not in xml)"       ,read_start_pattern_inj_    ,start_pattern_inj_, print_errors);
     //
     //------------------------------------------------------------------
     //0X4A,4C,4E = ADR_HCM001,HCM023,HCM045 = CFEB0 Hot Channel Masks
@@ -8921,7 +8915,7 @@ void TMB::CheckTMBConfiguration(int max_number_of_reads) {
     config_ok &= compareValues("TMB Initiate sequencer trigger from VME (not in xml)"     ,read_vme_ext_trig_      ,vme_ext_trig_         , print_errors);
     config_ok &= compareValues("TMB Make clct_ext_trig fire pattern injector (not in xml)",read_ext_trig_inject_   ,ext_trig_inject_      , print_errors);
     config_ok &= compareValues("TMB all_cfeb_active"                                      ,read_all_cfeb_active_   ,all_cfeb_active_      , print_errors);
-    config_ok &= compareValues("TMB enableCLCTInputs_reg68"                               ,read_cfebs_enabled_     ,cfebs_enabled_expected, print_errors);
+    config_ok &= compareValues("TMB enableCLCTInputs_reg68(+17A)"                         ,GetReadCfebEnable()     ,cfebs_enabled_expected, print_errors);
     config_ok &= compareValues("TMB cfeb_enable_source"                                   ,read_cfeb_enable_source_,cfeb_enable_source_   , print_errors);
     //
     //------------------------------------------------------------------
@@ -9227,12 +9221,12 @@ void TMB::CheckTMBConfiguration(int max_number_of_reads) {
     //------------------------------------------------------------------
     //0X17A = ADR_V6_EXTEND: ADR_CFEB_INJ:  CFEB Injector Control; ADR_SEQ_TRIG_EN:
     //------------------------------------------------------------------
-    if (hardware_version_>=2){
-      config_ok &= compareValues("TMB enableCLCTInputs_reg42 Extension"                 ,read_enableCLCTInputs_extend_       ,enableCLCTInputs_extend_     , print_errors);
-      config_ok &= compareValues("TMB Select CFEB56 n for RAM read/write (not in xml)"  ,read_cfeb_ram_sel_extend_           ,cfeb_ram_sel_extend_         , print_errors);
-      config_ok &= compareValues("TMB Enable CFEB56 n for injector trigger (not in xml)",read_cfeb_inj_en_sel_extend_        ,cfeb_inj_en_sel_extend_      , print_errors); 
-      config_ok &= compareValues("TMB enableCLCTInputs_reg68 Extension"                 ,read_cfebs_enabled_extend_          ,cfebs_enabled_extend_expected, print_errors);
-      config_ok &= compareValues("TMB enableCLCTInputs_reg68 Extension Readback"        ,read_cfebs_enabled_extend_readback_ ,cfebs_enabled_extend_expected, print_errors);
+    if (hardware_version_>=2){//this configuration is already fused into 0x42 and 0x68 configs
+      //      config_ok &= compareValues("TMB enableCLCTInputs_reg42 Extension"                 ,read_enableCLCTInputs_extend_       ,enableCLCTInputs_extend_     , print_errors);
+      //      config_ok &= compareValues("TMB Select CFEB56 n for RAM read/write (not in xml)"  ,read_cfeb_ram_sel_extend_           ,cfeb_ram_sel_extend_         , print_errors);
+      //      config_ok &= compareValues("TMB Enable CFEB56 n for injector trigger (not in xml)",read_cfeb_inj_en_sel_extend_        ,cfeb_inj_en_sel_extend_      , print_errors); 
+      //      config_ok &= compareValues("TMB enableCLCTInputs_reg68 Extension"                 ,read_cfebs_enabled_extend_          ,cfebs_enabled_extend_expected, print_errors);
+      //      config_ok &= compareValues("TMB enableCLCTInputs_reg68 Extension Readback"        ,read_cfebs_enabled_extend_readback_ ,cfebs_enabled_extend_expected, print_errors);
     }
     //
   }


### PR DESCRIPTION
- updated ChamberUtilities CFEBStripScan to handle 7 CFEBs where available [reported by Dave]
- CalibDAQ enables all 7 CLCT inputs (TMB will set 5 or 7 depending on the version)
- updated TMB {Get,Set,GetRead}{EnableCLCTInputs, SelectCLCTRAM, EnableCLCTInject} methods to return consistent to fix the XML->DB parser issues [reported by Evaldas]
  - Get will always return what was done with Set
  - GetRead will return a fused 7-bit value when 7 CFEBs are available
  - corresponding register I/O and config checking inside TMB is updated to handle the enableCLCTInputs_ cfeb_ram_sel_ cfeb_inj_en_sel_ cfebs_enabled_ as up to 7-wide bit fields covering all CFEBs
