### PR TITLE
change names of 0x186 and 0x190 registers/counters

### DIFF
--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
@@ -9230,20 +9230,20 @@ void EmuPeripheralCrateConfig::TMBStatus(xgi::Input * in, xgi::Output * out )
   if (thisTMB->GetHardwareVersion() >= 2) {
     *out << cgicc::fieldset();
     *out << cgicc::legend("Configuration and programming timers (100 nanosecond units)").set("style","color:blue") << std::endl;
-    thisTMB->ReadRegister(tmb_mmcm_lock_time_adr);
+    thisTMB->ReadRegister(tmb_mez_fpga_jtag_count_adr);
     thisTMB->ReadRegister(tmb_power_up_time_adr);
     thisTMB->ReadRegister(tmb_load_cfg_time_adr);
     thisTMB->ReadRegister(alct_phaser_lock_time_adr);
     thisTMB->ReadRegister(alct_load_cfg_time_adr);
-    thisTMB->ReadRegister(gtx_rst_done_time_adr);
+    thisTMB->ReadRegister(cfeb_fiber_phaser_lock_time_adr);
     thisTMB->ReadRegister(gtx_sync_done_time_adr);
     *out << cgicc::pre() << std::endl;
-    *out << "Special Test counter                          = " << thisTMB->GetReadTMBMMCMLockTime() << std::endl;
+    *out << "FPGA Mez JTAG Chain Access Count              = " << thisTMB->GetReadMezFpgaJtagCount() << std::endl;
     *out << "TMB Power Up Time                             = " << thisTMB->GetReadTMBPowerUpTime() << std::endl;
     *out << "TMB Load Cfg Time                             = " << thisTMB->GetReadTMBLoadCfgTime() << std::endl;
     *out << "ALCT Phaser Lock Time                         = " << thisTMB->GetReadALCTPhaserLockTime() << std::endl;
     *out << "ALCT Load Cfg Time (after ALCT startup delay) = " << thisTMB->GetReadALCTLoadCfgTime() << std::endl;
-    *out << "Gtx Rst Done Time                             = " << thisTMB->GetReadGtxRstDoneTime() << std::endl;
+    *out << "Comparator Fiber Phaser Lock Time             = " << thisTMB->GetReadCfebFiberPhaserLockTime() << std::endl;
     *out << "Gtx Sync Done Time                            = " << thisTMB->GetReadGtxSyncDoneTime() << std::endl;
     *out << cgicc::pre() << std::endl;
     *out << cgicc::fieldset();

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
@@ -9235,7 +9235,7 @@ void EmuPeripheralCrateConfig::TMBStatus(xgi::Input * in, xgi::Output * out )
     thisTMB->ReadRegister(tmb_load_cfg_time_adr);
     thisTMB->ReadRegister(alct_phaser_lock_time_adr);
     thisTMB->ReadRegister(alct_load_cfg_time_adr);
-    thisTMB->ReadRegister(cfeb_fiber_phaser_lock_time_adr);
+    thisTMB->ReadRegister(gtx_phaser_lock_time_adr);
     thisTMB->ReadRegister(gtx_sync_done_time_adr);
     *out << cgicc::pre() << std::endl;
     *out << "FPGA Mez JTAG Chain Access Count              = " << thisTMB->GetReadMezFpgaJtagCount() << std::endl;
@@ -9243,7 +9243,7 @@ void EmuPeripheralCrateConfig::TMBStatus(xgi::Input * in, xgi::Output * out )
     *out << "TMB Load Cfg Time                             = " << thisTMB->GetReadTMBLoadCfgTime() << std::endl;
     *out << "ALCT Phaser Lock Time                         = " << thisTMB->GetReadALCTPhaserLockTime() << std::endl;
     *out << "ALCT Load Cfg Time (after ALCT startup delay) = " << thisTMB->GetReadALCTLoadCfgTime() << std::endl;
-    *out << "Comparator Fiber Phaser Lock Time             = " << thisTMB->GetReadCfebFiberPhaserLockTime() << std::endl;
+    *out << "Comparator Fiber Phaser Lock Time             = " << thisTMB->GetReadGtxPhaserLockTime() << std::endl;
     *out << "Gtx Sync Done Time                            = " << thisTMB->GetReadGtxSyncDoneTime() << std::endl;
     *out << cgicc::pre() << std::endl;
     *out << cgicc::fieldset();

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -2365,9 +2365,9 @@ public:
   //---------------------------------------------------------------------
   inline int GetReadALCTLoadCfgTime() { return read_alct_load_cfg_time_;}
   //---------------------------------------------------------------------
-  // 0X190 = ADR_CFEB_FIBER_PHASER_LOCK_TIME
+  // 0X190 = ADR_GTX_PHASER_LOCK_TIME
   //---------------------------------------------------------------------
-  inline int GetReadCfebFiberPhaserLockTime() { return read_cfeb_fiber_phaser_lock_time_;}
+  inline int GetReadGtxPhaserLockTime() { return read_gtx_phaser_lock_time_;}
   //---------------------------------------------------------------------
   // 0X192 = ADR_GTX_SYNC_DONE_TIME
   //---------------------------------------------------------------------
@@ -3809,9 +3809,9 @@ private:
   int read_alct_load_cfg_time_;
   //
   //---------------------------------------------------------------------
-  // 0X190 = ADR_CFEB_FIBER_PHASER_LOCK_TIME
+  // 0X190 = ADR_GTX_PHASER_LOCK_TIME
   //---------------------------------------------------------------------
-  int read_cfeb_fiber_phaser_lock_time_;
+  int read_gtx_phaser_lock_time_;
   //
   //---------------------------------------------------------------------
   // 0X192 = ADR_GTX_SYNC_DONE_TIME

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB.h
@@ -2345,9 +2345,9 @@ public:
   //
   //
   //---------------------------------------------------------------------
-  // 0X186 = ADR_TMB_MMCM_LOCK_TIME
+  // 0X186 = ADR_MEZ_FPGA_JTAG_COUNT
   //---------------------------------------------------------------------
-  inline int GetReadTMBMMCMLockTime() { return read_tmb_mmcm_lock_time_;}
+  inline int GetReadMezFpgaJtagCount() { return read_mez_fpga_jtag_count_;}
   //---------------------------------------------------------------------
   // 0X188 = ADR_TMB_POWER_UP_TIME
   //---------------------------------------------------------------------
@@ -2365,9 +2365,9 @@ public:
   //---------------------------------------------------------------------
   inline int GetReadALCTLoadCfgTime() { return read_alct_load_cfg_time_;}
   //---------------------------------------------------------------------
-  // 0X190 = ADR_GTX_RST_DONE_TIME
+  // 0X190 = ADR_CFEB_FIBER_PHASER_LOCK_TIME
   //---------------------------------------------------------------------
-  inline int GetReadGtxRstDoneTime() { return read_gtx_rst_done_time_;}
+  inline int GetReadCfebFiberPhaserLockTime() { return read_cfeb_fiber_phaser_lock_time_;}
   //---------------------------------------------------------------------
   // 0X192 = ADR_GTX_SYNC_DONE_TIME
   //---------------------------------------------------------------------
@@ -3784,9 +3784,9 @@ private:
   int read_cfebs_enabled_extend_;
   int read_cfebs_enabled_extend_readback_;
   //---------------------------------------------------------------------
-  // 0X186 = ADR_TMB_MMCM_LOCK_TIME
+  // 0X186 = ADR_MEZ_FPGA_JTAG_COUNT
   //---------------------------------------------------------------------
-  int read_tmb_mmcm_lock_time_;
+  int read_mez_fpga_jtag_count_;
   //
   //---------------------------------------------------------------------
   // 0X188 = ADR_TMB_POWER_UP_TIME
@@ -3809,9 +3809,9 @@ private:
   int read_alct_load_cfg_time_;
   //
   //---------------------------------------------------------------------
-  // 0X190 = ADR_GTX_RST_DONE_TIME
+  // 0X190 = ADR_CFEB_FIBER_PHASER_LOCK_TIME
   //---------------------------------------------------------------------
-  int read_gtx_rst_done_time_;
+  int read_cfeb_fiber_phaser_lock_time_;
   //
   //---------------------------------------------------------------------
   // 0X192 = ADR_GTX_SYNC_DONE_TIME

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
@@ -361,7 +361,7 @@ static const unsigned long int tmb_power_up_time_adr    = 0x000188;
 static const unsigned long int tmb_load_cfg_time_adr    = 0x00018A;
 static const unsigned long int alct_phaser_lock_time_adr= 0x00018C;
 static const unsigned long int alct_load_cfg_time_adr   = 0x00018E;
-static const unsigned long int cfeb_fiber_phaser_lock_time_adr = 0x000190;
+static const unsigned long int gtx_phaser_lock_time_adr = 0x000190;
 static const unsigned long int gtx_sync_done_time_adr   = 0x000192;
 
 //

--- a/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
+++ b/emuDCS/PeripheralCore/include/emu/pc/TMB_constants.h
@@ -356,12 +356,12 @@ static const unsigned long int  hcm645_adr              = 0x000178;
  static const unsigned long int  dcfeb_inj_seq_trig_adr = 0x00017A;
 
 // config timers on OTMB
-static const unsigned long int tmb_mmcm_lock_time_adr   = 0x000186;
+static const unsigned long int tmb_mez_fpga_jtag_count_adr   = 0x000186;
 static const unsigned long int tmb_power_up_time_adr    = 0x000188;
 static const unsigned long int tmb_load_cfg_time_adr    = 0x00018A;
 static const unsigned long int alct_phaser_lock_time_adr= 0x00018C;
 static const unsigned long int alct_load_cfg_time_adr   = 0x00018E;
-static const unsigned long int gtx_rst_done_time_adr    = 0x000190;
+static const unsigned long int cfeb_fiber_phaser_lock_time_adr = 0x000190;
 static const unsigned long int gtx_sync_done_time_adr   = 0x000192;
 
 //

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -6964,8 +6964,8 @@ void TMB::DecodeTMBRegister_(unsigned long int address, int data) {
     read_alct_phaser_lock_time_ = ExtractValueFromData(data,0,15);
   } else if ( address == alct_load_cfg_time_adr) {
     read_alct_load_cfg_time_ = ExtractValueFromData(data,0,15);
-  } else if ( address == cfeb_fiber_phaser_lock_time_adr) {
-    read_cfeb_fiber_phaser_lock_time_ = ExtractValueFromData(data,0,15);
+  } else if ( address == gtx_phaser_lock_time_adr) {
+    read_gtx_phaser_lock_time_ = ExtractValueFromData(data,0,15);
   } else if ( address == gtx_sync_done_time_adr) {
     read_gtx_sync_done_time_ = ExtractValueFromData(data,0,15);
   }

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -6954,8 +6954,8 @@ void TMB::DecodeTMBRegister_(unsigned long int address, int data) {
     read_cfebs_enabled_extend_          = ExtractValueFromData(data,cfebs_enabled_extend_bitlo           ,cfebs_enabled_extend_bithi         );
     read_cfebs_enabled_extend_readback_ = ExtractValueFromData(data,cfebs_enabled_extend_readback_bitlo  ,cfebs_enabled_extend_readback_bithi);
     //
-  } else if ( address == tmb_mmcm_lock_time_adr) {
-    read_tmb_mmcm_lock_time_ = ExtractValueFromData(data,0,15);
+  } else if ( address == tmb_mez_fpga_jtag_count_adr) {
+    read_mez_fpga_jtag_count_ = ExtractValueFromData(data,0,15);
   } else if ( address == tmb_power_up_time_adr) {
     read_tmb_power_up_time_ = ExtractValueFromData(data,0,15);
   } else if ( address == tmb_load_cfg_time_adr) {
@@ -6964,8 +6964,8 @@ void TMB::DecodeTMBRegister_(unsigned long int address, int data) {
     read_alct_phaser_lock_time_ = ExtractValueFromData(data,0,15);
   } else if ( address == alct_load_cfg_time_adr) {
     read_alct_load_cfg_time_ = ExtractValueFromData(data,0,15);
-  } else if ( address == gtx_rst_done_time_adr) {
-    read_gtx_rst_done_time_ = ExtractValueFromData(data,0,15);
+  } else if ( address == cfeb_fiber_phaser_lock_time_adr) {
+    read_cfeb_fiber_phaser_lock_time_ = ExtractValueFromData(data,0,15);
   } else if ( address == gtx_sync_done_time_adr) {
     read_gtx_sync_done_time_ = ExtractValueFromData(data,0,15);
   }


### PR DESCRIPTION
Names changed
- for 0x186 from tmb_mmcm_lock_time_adr to tmb_mez_fpga_jtag_count_adr
  - Text on TMB status page changes from `Special Test counter` to `FPGA Mez JTAG Chain Access Count`
- for 0x190 from gtx_rst_done_time_adr to gtx_phaser_lock_time_adr
  - Text in TMB status page changes from `Gtx Rst Done Time` to `Comparator Fiber Phaser Lock Time`
