### PR TITLE
Compiler warning cleanup in emu/

### DIFF
--- a/base/src/common/utils/DOM.cc
+++ b/base/src/common/utils/DOM.cc
@@ -1086,12 +1086,16 @@ std::string emu::utils::removeSelectedNode( const std::string& XML,
       case DOMNode::ELEMENT_NODE:
       case DOMNode::TEXT_NODE:
       case DOMNode::PROCESSING_INSTRUCTION_NODE:
-      case DOMNode::COMMENT_NODE:
+      case DOMNode::COMMENT_NODE: {
 	(*dn)->getParentNode()->removeChild( *dn );
 	break;
-      case DOMNode::ATTRIBUTE_NODE:
+      }
+      case DOMNode::ATTRIBUTE_NODE: {
 	DOMAttr *attr = dynamic_cast<DOMAttr*>(*dn);
 	attr->getOwnerElement()->removeAttributeNode( attr );
+	break;
+      }
+      default:
 	break;
 	// We don't handle other types of nodes
       }

--- a/emuDCS/FEDApps/src/common/EmuFCrateHyperDAQ.cc
+++ b/emuDCS/FEDApps/src/common/EmuFCrateHyperDAQ.cc
@@ -1296,7 +1296,7 @@ void emu::fed::EmuFCrateHyperDAQ::DDUBroadcast(xgi::Input *in, xgi::Output *out)
 					// Match usercode against PROM code
 					slotTable(iDDU + 1,3 + iprom).setClass("bad");
 					
-				} else if (fpgaCode & 0x000ff000 != promCode & 0x00ff0000) {
+				} else if ((fpgaCode & 0x000ff000) != (promCode & 0x00ff0000)) {
 					// Match usercode against FPGA code
 					slotTable(iDDU + 1,3 + iprom).setClass("questionable");
 				}
@@ -1308,7 +1308,7 @@ void emu::fed::EmuFCrateHyperDAQ::DDUBroadcast(xgi::Input *in, xgi::Output *out)
 			} else if (dduPROMTypes[iprom] == INPROM0 || dduPROMTypes[iprom] == INPROM1) {
 				// INPROMs have a special FPGA code
 				
-				if (fpgaCode & 0x00ffffff != promCode & 0x00ffffff) {
+			        if ((fpgaCode & 0x00ffffff) != (promCode & 0x00ffffff)) {
 					slotTable(iDDU + 1,3 + iprom).setClass("bad");
 				}
 			}
@@ -4297,9 +4297,9 @@ void emu::fed::EmuFCrateHyperDAQ::VMEPARA(xgi::Input *in, xgi::Output *out)
 				.set("class",iComment->second);
 		}
 		statusTable(1,1).setClass("ok");
-		if ((parallelStat >> 8) & 0xF == 0x4) statusTable(1,1).setClass("warning");
-		else if ((parallelStat >> 8) & 0xF == 0x1) statusTable(1,1).setClass("questionable");
-		else if ((parallelStat >> 8) & 0xF != 0x8) statusTable(1,1).setClass("bad");
+		if (((parallelStat >> 8) & 0xF) == 0x4) statusTable(1,1).setClass("warning");
+		else if (((parallelStat >> 8) & 0xF) == 0x1) statusTable(1,1).setClass("questionable");
+		else if (((parallelStat >> 8) & 0xF) != 0x8) statusTable(1,1).setClass("bad");
 
 		int dduFMM = (parallelStat >> 8) & 0xf;
 		statusTable(2,0) << "DDU FMM status";
@@ -4312,9 +4312,9 @@ void emu::fed::EmuFCrateHyperDAQ::VMEPARA(xgi::Input *in, xgi::Output *out)
 				.set("class",iComment->second);
 		}
 		statusTable(2,1).setClass("ok");
-		if (dduFMM & 0xF == 0x4) statusTable(2,1).setClass("warning");
-		else if (dduFMM & 0xF == 0x1) statusTable(2,1).setClass("questionable");
-		else if (dduFMM & 0xF != 0x8) statusTable(2,1).setClass("bad");
+		if ((dduFMM & 0xF) == 0x4) statusTable(2,1).setClass("warning");
+		else if ((dduFMM & 0xF) == 0x1) statusTable(2,1).setClass("questionable");
+		else if ((dduFMM & 0xF) != 0x8) statusTable(2,1).setClass("bad");
 
 		*out << statusTable.printSummary() << std::endl;
 
@@ -4619,8 +4619,8 @@ void emu::fed::EmuFCrateHyperDAQ::VMESERI(xgi::Input *in, xgi::Output *out)
 		ramStatusTable(1,0) << "Serial Flash RAM Status";
 		ramStatusTable(1,1) << std::showbase << std::hex << ramStatus;
 		ramStatusTable(1,1).setClass("ok");
-		if (ramStatus & 0x003c != 0x000c) ramStatusTable(1,1).setClass("warning");
-		if (ramStatus & 0x0080 != 0x0080) ramStatusTable(1,1).setClass("bad");
+		if ((ramStatus & 0x003c) != 0x000c) ramStatusTable(1,1).setClass("warning");
+		if ((ramStatus & 0x0080) != 0x0080) ramStatusTable(1,1).setClass("bad");
 
 		// Print the table summary
 		*out << ramStatusTable.printSummary() << std::endl;

--- a/emuDCS/FEDCore/src/common/DCC.cc
+++ b/emuDCS/FEDCore/src/common/DCC.cc
@@ -22,7 +22,7 @@ slink2_id_(0)
 
 	// MPROM is one element
 	JTAGChain chainMPROM;
-	chainMPROM.push_back(new JTAGElement("MPROM", MPROM, 2, MPROM_BYPASS_L | (MPROM_BYPASS_H << 8), 16, 0x00002000, false));
+	chainMPROM.push_back(new JTAGElement("MPROM", MPROM, 2, int16_t(MPROM_BYPASS_L | (MPROM_BYPASS_H << 8)), 16, 0x00002000, false));
 	JTAGMap[MPROM] = chainMPROM;
 
 	// INPROM is one element

--- a/emuDCS/FEDUtils/src/common/DCCDebugger.cc
+++ b/emuDCS/FEDUtils/src/common/DCCDebugger.cc
@@ -15,7 +15,7 @@ const std::multimap<std::string, std::string> emu::fed::DCCDebugger::FMMStatus(c
 {
 	// Only read the low 5 bits
 	std::multimap<std::string, std::string> returnMe;
-	if (0xf & stat == 0xc) returnMe.insert(std::make_pair("error", "Error")); // used to be 3
+	if ( (0xf & stat) == 0xc) returnMe.insert(std::make_pair("error", "Error")); // used to be 3
 	else if (0x4 & stat) returnMe.insert(std::make_pair("caution", "Busy")); // used to be 1
 	else if (0x8 & stat) returnMe.insert(std::make_pair("ok", "Ready")); // used to be 2
 	else if (0x1 & stat) returnMe.insert(std::make_pair("warning", "Warning")); // used to be 4
@@ -37,7 +37,7 @@ const std::multimap<std::string, std::string> emu::fed::DCCDebugger::FMM(const u
 	for (unsigned int i = 0; i < 3; ++i) {
 		const uint16_t myStat = (stat >> (i * 5));
 		const std::string name = names[i];
-		if (0xf & myStat == 0xc) returnMe.insert(std::make_pair("error", name + " Error")); // used to be 3
+		if ( (0xf & myStat) == 0xc) returnMe.insert(std::make_pair("error", name + " Error")); // used to be 3
 		else if (0x4 & myStat) returnMe.insert(std::make_pair("caution", name + " Busy")); // used to be 1
 		else if (0x8 & myStat) returnMe.insert(std::make_pair("ok", name + " Ready")); // used to be 2
 		else if (0x1 & myStat) returnMe.insert(std::make_pair("warning", name + " Warning")); // used to be 4

--- a/emuDCS/FEDUtils/src/common/DDUDebugger.cc
+++ b/emuDCS/FEDUtils/src/common/DDUDebugger.cc
@@ -35,7 +35,7 @@ std::map<std::string, std::string> emu::fed::DDUDebugger::FPGAStatus(const enum 
 				if (0x00400000&stat) returnMe["InRDctrl Error"] = "red";
 				if (0x00200000&stat) returnMe["DAQ Stop bit set"] = "blue";
 				if (0x00100000&stat) returnMe["DAQ says Not Ready"] = "blue";
-				if (0x00300000&stat == 0x00200000) returnMe["DAQ Applied Backpressure"] = "blue";
+				if ( (0x00300000&stat) == 0x00200000) returnMe["DAQ Applied Backpressure"] = "blue";
 			}
 			if (stat&0x000F0000) {
 				if (0x00080000&stat) returnMe["TMB Error"] = "orange";
@@ -1414,7 +1414,7 @@ std::map<std::string, std::string> emu::fed::DDUDebugger::FFError(const uint16_t
 	}
 	
 	if (0x4000 & stat) returnMe["L1A FIFO Empty"] = "none";
-	if (0x4000 & stat == 0) returnMe["L1A FIFO Not Empty"] = "none";
+	if ( (0x4000 & stat) == 0) returnMe["L1A FIFO Not Empty"] = "none";
 	if (0x0200 & stat) returnMe["GbE FIFO Full occurred"] = "yellow";
 	if (0x0100 & stat) returnMe["L1A FIFO Full occurred"] = "red";
 	
@@ -1485,7 +1485,7 @@ std::map<std::string, std::string> emu::fed::DDUDebugger::FIFOStatus(const enum 
 			if (stat & 0xb300) {
 
 				if (0x0040 & stat) returnMe["L1A FIFO Empty"] = "none";
-				if (0x0040 & stat == 0) returnMe["L1A FIFO Not Empty"] = "none";
+				if ( (0x0040 & stat) == 0) returnMe["L1A FIFO Not Empty"] = "none";
 				if (0x0080 & stat) returnMe["DDU C-code L1A error"] = "blue";
 				if (0x0002 & stat) returnMe["GbE FIFO Almost-Full occurred"] = "none";
 				if (0x0001 & stat) returnMe["L1A FIFO Almost-Full occurred"] = "blue";
@@ -1539,7 +1539,7 @@ std::map<std::string, std::string> emu::fed::DDUDebugger::FIFOStatus(const enum 
 			if (0x0010 & stat) returnMe["L1A FIFO " + fifoName + " Almost Full"] = "blue";
 			if (0x0004 & stat) returnMe["MemCtrl " + fifoName + " Almost Full"] = "blue";
 			if (0x0001 & stat) returnMe["L1A FIFO " + fifoName + " Empty"] = "none";
-			if (0x0001 & stat == 0) returnMe["L1A FIFO " + fifoName + " Not Empty"] = "none";
+			if ( (0x0001 & stat) == 0) returnMe["L1A FIFO " + fifoName + " Not Empty"] = "none";
 		}
 		if (stat & 0x00AA) {
 			std::string fifoName = (dev == INFPGA0 ? "2" : "4");
@@ -1547,7 +1547,7 @@ std::map<std::string, std::string> emu::fed::DDUDebugger::FIFOStatus(const enum 
 			if (0x0020 & stat) returnMe["L1A FIFO " + fifoName + " Almost Full"] = "blue";
 			if (0x0008 & stat) returnMe["MemCtrl " + fifoName + " Almost Full"] = "blue";
 			if (0x0002 & stat) returnMe["L1A FIFO " + fifoName + " Empty"] = "none";
-			if (0x0002 & stat == 0) returnMe["L1A FIFO " + fifoName + " Not Empty"] = "none";
+			if ( (0x0002 & stat) == 0) returnMe["L1A FIFO " + fifoName + " Not Empty"] = "none";
 		}
 	} else {
 		// FIXME error
@@ -1704,13 +1704,13 @@ std::map<std::string, std::string> emu::fed::DDUDebugger::AvailableMemory(const 
 	
 	std::ostringstream status;
 	status << "Fibers " << (dev == INFPGA0 ? 0 : 8) << "-" << (dev == INFPGA0 ? 3 : 11) << ": " << (stat & 0x1f) << " units";
-	if (stat & 0x1f == 1) returnMe[status.str()] = "orange";
+	if ( (stat & 0x1f) == 1) returnMe[status.str()] = "orange";
 	else if (!(stat & 0x1f)) returnMe[status.str()] = "red";
 	else returnMe[status.str()] = "none";
 
 	status.str("");
 	status << "Fibers " << (dev == INFPGA0 ? 4 : 12) << "-" << (dev == INFPGA0 ? 7 : 14) << ": " << ((stat >> 5) & 0x1f) << " units";
-	if ((stat >> 5) & 0x1f == 1) returnMe[status.str()] = "orange";
+	if ( ((stat >> 5) & 0x1f) == 1) returnMe[status.str()] = "orange";
 	else if (!((stat >> 5) & 0x1f)) returnMe[status.str()] = "red";
 	else returnMe[status.str()] = "none";
 	

--- a/emuDCS/PeripheralApps/include/emu/pc/ChamberUtilities.h
+++ b/emuDCS/PeripheralApps/include/emu/pc/ChamberUtilities.h
@@ -142,9 +142,10 @@ public:
     int cfeb_rx_posneg;
     int cfeb_rx_clock_delay;
     
+    int cfeb_clock_phase;
+
     int cfeb_mask;
     
-    int cfeb_clock_phase;
     inline CFEBTiming_Configuration():
       cfeb_pipeline_depth(0),
       dac(0),

--- a/emuDCS/PeripheralApps/include/emu/pc/ChamberUtilities.h
+++ b/emuDCS/PeripheralApps/include/emu/pc/ChamberUtilities.h
@@ -174,7 +174,6 @@ public:
       cfeb_pipeline_depth(o.cfeb_pipeline_depth),
       dac(o.dac),
       comp_thresh(o.comp_thresh),
-      tmb_internal_l1a(o.tmb_internal_l1a),
       clct_pattern_trig_en(o.clct_pattern_trig_en),
       clct_ext_trig_en(o.clct_ext_trig_en),
       tmb_allow_clct(o.tmb_allow_clct),
@@ -186,6 +185,7 @@ public:
       fifo_tbins(o.fifo_tbins),
       fifo_pretrig(o.fifo_pretrig),
       fifo_no_hits_raw(o.fifo_no_hits_raw),
+      tmb_internal_l1a(o.tmb_internal_l1a),
       ccb_ext_trig_delay(o.ccb_ext_trig_delay),
       tmb_l1a_delay(o.tmb_l1a_delay),
       cfeb_rx_posneg(o.cfeb_rx_posneg),
@@ -203,12 +203,12 @@ public:
 
   inline bool CFEBTiming_CheckConfiguration(const CFEBTiming_Configuration & orig); 
 
-  inline void ConfigureTMB(const CFEBTiming_Configuration & config, int * cfeb_tof_delay);
+  void ConfigureTMB(const CFEBTiming_Configuration & config, int * cfeb_tof_delay);
   inline void ConfigureTMB(const CFEBTiming_Configuration & config) {	  
     return ConfigureTMB(config, NULL);
   }
 
-  inline void CFEBTiming_ConfigureLevel(CFEBTiming_Configuration & config, int level, int after);
+  void CFEBTiming_ConfigureLevel(CFEBTiming_Configuration & config, int level, int after);
   inline void CFEBTiming_ConfigureLevel(CFEBTiming_Configuration & config, int level) {
     return CFEBTiming_ConfigureLevel(config, level, false);
   }

--- a/emuDCS/PeripheralApps/include/emu/pc/EmuCompareMcsFiles.h
+++ b/emuDCS/PeripheralApps/include/emu/pc/EmuCompareMcsFiles.h
@@ -72,7 +72,7 @@ private:
   xdata::UnsignedShort fastloop, slowloop, extraloop;
   bool newfile, file_loaded[2], file_checked[2], file_valid[2], compared, identical;
   int error_idx[200], bit_error, byte_error;
-  char *temp_mcsname[2];
+  const char *temp_mcsname[2];
   std::string original_file[2];
   char comment1_buf[4096], comment2_buf[4096];
   char *bbuf1, *bbuf2;

--- a/emuDCS/PeripheralApps/include/emu/pc/EmuPeripheralCrateCommand.h
+++ b/emuDCS/PeripheralApps/include/emu/pc/EmuPeripheralCrateCommand.h
@@ -345,7 +345,7 @@ private:
   int VerifyCCBs();
 
   // alct calibration Madorsky
-  int read_test_config(char* xmlFile, test_config_struct * tcs);
+  int read_test_config(const char* xmlFile, test_config_struct * tcs);
   std::string& trim(std::string &str);
   test_config_struct tcs;
   int calsetup;

--- a/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
+++ b/emuDCS/PeripheralApps/src/common/ChamberUtilities.cc
@@ -1143,7 +1143,7 @@ inline void ChamberUtilities::CFEBTiming_ConfigureLevel(CFEBTiming_Configuration
   }
   if(level == 2) {
     if(is_me11_) {
-      for(int cfeb=0, int ncfeb=thisDMB->cfebs_.size(); cfeb<ncfeb; ++cfeb) {
+      for(int cfeb=0, ncfeb=thisDMB->cfebs_.size(); cfeb<ncfeb; ++cfeb) {
 	if((config.cfeb_mask & 0x7f) >> thisDMB->cfebs_[cfeb].number()) {
 	  
 	  // Should not set dcfeb_clock_phase with the following function for regular scan, but should pick up the dcfeb_clock_phase that is set in xml
@@ -1567,7 +1567,7 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
     usleep(1000000);
     CFEBTiming_CheckConfiguration(config);
     
-    for(int cfeb=0, int ncfebs=thisDMB->cfebs_.size(); cfeb<ncfebs; ++cfeb) {	
+    for(int cfeb=0, ncfebs=thisDMB->cfebs_.size(); cfeb<ncfebs; ++cfeb) {	
       
       char tmp[2];
       // Reads out and saves current DCFEB clock phase for each DCFEB
@@ -2312,7 +2312,7 @@ void ChamberUtilities::CFEBTiming_with_Posnegs_simple_routine(int time_delay, in
       (*MyOutput_) << "Reverting back to original DCFEB clock phase values..." << std::endl << std::endl;
       web_backup << "Reverting back to original DCFEB clock phase values..." << std::endl << std::endl;
       //
-      for(int cfeb=0; cfeb<thisDMB->cfebs_.size(); ++cfeb) {
+      for(int cfeb=0, ncfebs=thisDMB->cfebs_.size(); cfeb<ncfebs; ++cfeb) {
 	if((config.cfeb_mask & 0x7f) >> thisDMB->cfebs_[cfeb].number()) {
 	  
 	  thisDMB->dcfeb_fine_delay(thisDMB->cfebs_[cfeb], initial_cfeb_tof_delay[cfeb]);

--- a/emuDCS/PeripheralApps/src/common/EmuCompareMcsFiles.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuCompareMcsFiles.cc
@@ -138,7 +138,7 @@ void EmuCompareMcsFiles::MainPage(xgi::Input * in, xgi::Output * out )
 
      *out << cgicc::textarea().set("name","commands").set("WRAP","OFF").set("rows","20").set("cols","60");
         char bitprint[100];
-        char *bittitle=" Address         File #1         File #2       \n";
+        const char *bittitle=" Address         File #1         File #2       \n";
         memcpy(bitprint, bittitle, strlen(bittitle));
         *out << bittitle << std::endl;
         // display difference
@@ -307,7 +307,7 @@ int EmuCompareMcsFiles::binsize(int mcs, FILE *finp)
    unsigned ext_add, loc_add, dsize, current_ext=0, current_add;
    char buf[1024], addbuf[5]={0,0,0,0,0}, lenbuf[3]={0,0,0};
    int finish=0, segmented=0, lines=0, badlines=0;
-   char *tag1="995566AA", *tag2="5599AA66";
+   const char *tag1="995566AA", *tag2="5599AA66";
    int found1=0, found2=0, byte_swap=0;
 
    if (mcs<1 || mcs>2) return 0;

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateBase.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateBase.cc
@@ -261,7 +261,7 @@ std::string EmuPeripheralCrateBase::getLocalDateTime(bool AsFileName){
 bool EmuPeripheralCrateBase::CommonParser(std::string XML_or_DB, std::string configKey)
 {
   std::string Valid_key, InFlash_key;
-  xdata::UnsignedInteger64 Valid_key_64, InFlash_key_64;
+  xdata::UnsignedInteger64 Valid_key_64(0), InFlash_key_64(0);
 //  EmuEndcap* myEndcap_=NULL;
   int use_flash=0;
     //

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateCommand.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateCommand.cc
@@ -1048,7 +1048,7 @@ xoap::MessageReference EmuPeripheralCrateCommand::onEnableCalALCTDelays (xoap::M
 // macro to fill the parameter map
 #define map_add(tnum, parname) map##tnum[#parname] = &(tcs->t##tnum.parname)
 
-int EmuPeripheralCrateCommand::read_test_config(char* xmlFile, test_config_struct * tcs) 
+int EmuPeripheralCrateCommand::read_test_config(const char* xmlFile, test_config_struct * tcs) 
 {
 	char* step_path_ch = getenv("HOME");
 	if (step_path_ch == NULL) return -1;

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig.cc
@@ -5169,7 +5169,7 @@ void EmuPeripheralCrateConfig::ChamberTests(xgi::Input * in, xgi::Output * out )
   *out << cgicc::td().set("ALIGN", "left") << std::endl;
   *out << cgicc::select().set("name", "cfeb_num") << std::endl;
   *out << cgicc::option().set("value", toolbox::toString("%d", -1)) << "Scan" << cgicc::option() << std::endl;
-  for(int i=0; i<thisDMB->cfebs_.size(); ++i) *out << cgicc::option().set("value", toolbox::toString("%d", i)) << i << cgicc::option() << std::endl;
+  for(int i=0, ncfebs=thisDMB->cfebs_.size(); i<ncfebs; ++i) *out << cgicc::option().set("value", toolbox::toString("%d", i)) << i << cgicc::option() << std::endl;
   *out << cgicc::select() << std::endl;
   *out << cgicc::td();
   *out << cgicc::td().set("ALIGN", "left") << std::endl;
@@ -6813,7 +6813,7 @@ void EmuPeripheralCrateConfig::PipelineDepthScan( xgi::Input * in, xgi::Output *
 		      words[iWord%loneWordLength] = (*dmb)->odmb_read_tx_word();
 		      if ( (iWord%loneWordLength) + 1 == loneWordLength ){
 			bool isLoneWord = true;
-			for ( int i=0; i<loneWordLength; ++i ) isLoneWord &= ( words[i] & 0xf000 == 0x8000 );
+			for ( int i=0; i<loneWordLength; ++i ) isLoneWord &= ( (words[i] & 0xf000) == 0x8000 );
 			if ( !isLoneWord ){
 			  for ( int i=0; i<loneWordLength; ++i ) file.write( (char*)( words+i ), sizeof( unsigned short int ) );
 			}
@@ -7752,7 +7752,7 @@ void EmuPeripheralCrateConfig::TMBFiberReset(xgi::Input * in, xgi::Output * out)
   }
   //
   bool is_all = false;
-  int fiber_num;
+  int fiber_num = 0;
   if (fiber == "all") {
     is_all = true;
   } else {
@@ -7797,7 +7797,7 @@ void EmuPeripheralCrateConfig::TMBFiberReset(xgi::Input * in, xgi::Output * out)
   }
 
   thisTMB->ReadRegister(v6_gtx_rx_all_adr);
-  for (int i = 0; i < TMB_N_FIBERS; ++i) {
+  for (unsigned int i = 0; i < TMB_N_FIBERS; ++i) {
     unsigned long int adr = v6_gtx_rx0_adr + (unsigned long int) (2 * i);
     thisTMB->ReadRegister(adr);
   }

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig_VCC.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateConfig_VCC.cc
@@ -630,7 +630,7 @@ void EmuPeripheralCrateConfig::VCC_CMNTSK_DO(xgi::Input * in, xgi::Output * out 
     n = vmecc->eth_read();
     if(n>6){
       for(i=0;i<vmecc->nwbuf;i++){
-	if(vmecc->rbuf[DATA_OFF+i]&0xFF != lb_tst[i]&0xFF) tst_err = true;
+	if( (vmecc->rbuf[DATA_OFF+i]&0xFF) != (lb_tst[i]&0xFF) ) tst_err = true;
       }
       if(tst_err){
         VCC_UTIL_cmn_tsk_lpbk = "failed";

--- a/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateMonitor.cc
+++ b/emuDCS/PeripheralApps/src/common/EmuPeripheralCrateMonitor.cc
@@ -1451,7 +1451,7 @@ void EmuPeripheralCrateMonitor::DCSChamber(xgi::Input * in, xgi::Output * out )
   xdata::Vector<xdata::Float> *dcsdata = dynamic_cast<xdata::Vector<xdata::Float> *>(is->find("DCStemps"));
   if(dcsdata==NULL || dcsdata->size()==0) return;
   bool dcfebok=true;
-  xdata::Vector<xdata::Float> *dcfebdata;
+  xdata::Vector<xdata::Float> *dcfebdata(0);
   if(DHversion>=2)
   {
      dcfebdata = dynamic_cast<xdata::Vector<xdata::Float> *>(is->find("DCFEBmons"));

--- a/emuDCS/PeripheralCore/src/common/ALCTController.cc
+++ b/emuDCS/PeripheralCore/src/common/ALCTController.cc
@@ -1108,7 +1108,7 @@ int ALCTController::GetSlowControlVersionId() {
 }
 //
 int ALCTController::GetSlowControlYear() { 
-  return ((read_slowcontrol_id_[2]<<8) | read_slowcontrol_id_[1]&0xff); 
+  return ((read_slowcontrol_id_[2]<<8) | (read_slowcontrol_id_[1]&0xff)); 
 }
 //
 int ALCTController::GetSlowControlDay() { 
@@ -1474,7 +1474,7 @@ void ALCTController::WriteAfebThresholds() {
     // ..... and the DAC channel through TDI, again using the correct AFEB indexing 
     // (N.B. the Get..DAC() method already will access the correct threshold)
     int data_to_send = 
-      ( (afeb_dac_channel[UserIndexToHardwareIndex_(afebChannel)]<<8) & 0xf00 ) | GetAfebThresholdDAC(afebChannel) & 0xff;
+      ( (afeb_dac_channel[UserIndexToHardwareIndex_(afebChannel)]<<8) & 0xf00 ) | (GetAfebThresholdDAC(afebChannel) & 0xff);
     if (debug_)
       (*MyOutput_) << "User AFEB" << std::dec << afebChannel 
 		   << " writes to hardware AFEB " << UserIndexToHardwareIndex_(afebChannel)

--- a/emuDCS/PeripheralCore/src/common/ALCTController.cc
+++ b/emuDCS/PeripheralCore/src/common/ALCTController.cc
@@ -1834,7 +1834,7 @@ void ALCTController::ReadStandbyRegister_() {
 void ALCTController::PrintStandbyRegister_() {
   //
   const int buffersize = RegSizeAlctSlowFpga_RD_STANDBY_REG/8;
-  char tempBuffer[buffersize] = {};
+  char tempBuffer[buffersize+1] = {}; //SK: minimize line changes; code below already assumes it's 42-bit input
   tmb_->packCharBuffer(read_standby_register_,
 		       RegSizeAlctSlowFpga_RD_STANDBY_REG,
 		       tempBuffer);

--- a/emuDCS/PeripheralCore/src/common/Crate.cc
+++ b/emuDCS/PeripheralCore/src/common/Crate.cc
@@ -812,7 +812,7 @@ void Crate::MonitorDMB(int cycle, char * buf, unsigned mask)
   {
     int imask= 0x3F & (myDmbs[i]->GetPowerMask());
     bool chamber_on = (imask!=0x3F);
-    int Dversion=myDmbs[i]->GetHardwareVersion();
+    //SK: not used//    int Dversion=myDmbs[i]->GetHardwareVersion();
 
     if(IsAlive() && (mask & (1<<i))==0 && chamber_on)
     {  countbuf=myDmbs[i]->GetCounters();
@@ -861,8 +861,8 @@ void Crate::MonitorDCS(int cycle, char * buf, unsigned mask)
   {
     int imask= 0xFF & (myDmbs[i]->GetPowerMask());
     bool chamber_on = (imask!=0xFF);
-    int Dversion=myDmbs[i]->GetHardwareVersion();
-    int Tversion=myTmbs[i]->GetHardwareVersion();
+    //SK: not used//    int Dversion=myDmbs[i]->GetHardwareVersion();
+    //SK: not used//    int Tversion=myTmbs[i]->GetHardwareVersion();
 
     if(IsAlive() && (dmask & (1<<i))==0)
     {  
@@ -916,9 +916,9 @@ void Crate::MonitorDCS2(int cycle, char * buf, unsigned mask, bool read_dcfeb)
   for(unsigned i =0; i < myDmbs.size(); ++i) 
   {
     int imask= 0xFF & (myDmbs[i]->GetPowerMask());
-    bool chamber_on = (imask!=0xFF);
+    //SK: not used//    bool chamber_on = (imask!=0xFF);
     int Dversion=myDmbs[i]->GetHardwareVersion();
-    int Tversion=myTmbs[i]->GetHardwareVersion();
+    //SK: not used//    int Tversion=myTmbs[i]->GetHardwareVersion();
 
     if(IsAlive() && Dversion==2 && (dmask & (1<<i))==0)
     {  

--- a/emuDCS/PeripheralCore/src/common/Crate.cc
+++ b/emuDCS/PeripheralCore/src/common/Crate.cc
@@ -915,10 +915,10 @@ void Crate::MonitorDCS2(int cycle, char * buf, unsigned mask, bool read_dcfeb)
   std::vector<TMB*> myTmbs = this->tmbs();
   for(unsigned i =0; i < myDmbs.size(); ++i) 
   {
-    int imask= 0xFF & (myDmbs[i]->GetPowerMask());
-    //SK: not used//    bool chamber_on = (imask!=0xFF);
+    //SK: not used:    int imask= 0xFF & (myDmbs[i]->GetPowerMask());
+    //SK: not used:    bool chamber_on = (imask!=0xFF);
     int Dversion=myDmbs[i]->GetHardwareVersion();
-    //SK: not used//    int Tversion=myTmbs[i]->GetHardwareVersion();
+    //SK: not used:    int Tversion=myTmbs[i]->GetHardwareVersion();
 
     if(IsAlive() && Dversion==2 && (dmask & (1<<i))==0)
     {  

--- a/emuDCS/PeripheralCore/src/common/EMUjtag.cc
+++ b/emuDCS/PeripheralCore/src/common/EMUjtag.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <fstream>
 #include <sstream>
+#include <cmath>
 #include <time.h>
 #include <string.h>
 //
@@ -467,7 +468,7 @@ void EMUjtag::packCharBuffer(int * bitVector,
   // bitVector[0]     = LSB of charVector[0]
   // bitVector[Nbits] = MSB of charVector[Nbits/8]
   //
-  int nChars = ceil(Nbits/8.); 
+  int nChars = std::ceil(Nbits/8.); 
   for (int i=0; i<nChars; i++) 
     charVector[i] = 0;
   //

--- a/emuDCS/PeripheralCore/src/common/EMUjtag.cc
+++ b/emuDCS/PeripheralCore/src/common/EMUjtag.cc
@@ -467,7 +467,8 @@ void EMUjtag::packCharBuffer(int * bitVector,
   // bitVector[0]     = LSB of charVector[0]
   // bitVector[Nbits] = MSB of charVector[Nbits/8]
   //
-  for (int i=0; i<Nbits/8; i++) 
+  int nChars = ceil(Nbits/8.); 
+  for (int i=0; i<nChars; i++) 
     charVector[i] = 0;
   //
   int bufferbit = 0;

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -1739,7 +1739,7 @@ void TMB::scope(int scp_arm,int scp_readout, int scp_channel) {
 
   unsigned long int scope_ram[256][nrams];
   int scp_raw_data[nbits];
-  char *scope_ch[256];
+  const char *scope_ch[256];
   int scope_raw_decode = 1;
 
   unsigned long int runstop;
@@ -1908,8 +1908,8 @@ void TMB::scope(int scp_arm,int scp_readout, int scp_channel) {
     for(itbin=0;itbin<256;itbin++) {                      //256 time bins per channel
       //
       ibit = ((scope_ram[itbin][iram]) >> (ich%16) ) & 1; //logic levels vs tbin for this chan	      
-      if(ibit == 0) scope_ch[itbin] = '_';       //display symbol for logic 0
-      if(ibit == 1) scope_ch[itbin] = '-';       //display symbol for logic 1
+      if(ibit == 0) scope_ch[itbin] = "_";       //display symbol for logic 0
+      if(ibit == 1) scope_ch[itbin] = "-";       //display symbol for logic 1
       (*MyOutput_) << scope_ch[itbin];
       //
       // Construct integer for special channel groups

--- a/emuDCS/PeripheralCore/src/common/TMB.cc
+++ b/emuDCS/PeripheralCore/src/common/TMB.cc
@@ -1238,14 +1238,14 @@ void TMB::ReadBackMpcRAM(int nEvents){
     ramAdd = (evtId<<8);
     //
     sndbuf[0] = ((ramAdd)>>8)&0xff ;
-    sndbuf[1] = (ramAdd)&0xff | (0x1<<4) ;
+    sndbuf[1] = ((ramAdd)&0xff) | (0x1<<4) ;
     tmb_vme(VME_WRITE,mpc_ram_adr,sndbuf,rcvbuf,NOW);
     //
     tmb_vme(VME_READ,mpc_ram_rdata_adr,sndbuf,rcvbuf,NOW);
     unsigned long int rlct01 = ((rcvbuf[0]&0xff)<<8) | (rcvbuf[1]&0xff) ;
     //
     sndbuf[0] = ((ramAdd)>>8)&0xff ;
-    sndbuf[1] = (ramAdd)&0xff | (0x1<<5) ;
+    sndbuf[1] = ((ramAdd)&0xff) | (0x1<<5) ;
     tmb_vme(VME_WRITE,mpc_ram_adr,sndbuf,rcvbuf,NOW);
     //
     tmb_vme(VME_READ,mpc_ram_rdata_adr,sndbuf,rcvbuf,NOW);
@@ -1256,14 +1256,14 @@ void TMB::ReadBackMpcRAM(int nEvents){
     //
     //
     sndbuf[0] = ((ramAdd)>>8)&0xff ;
-    sndbuf[1] = (ramAdd)&0xff | (0x1<<6) ;
+    sndbuf[1] = ((ramAdd)&0xff) | (0x1<<6) ;
     tmb_vme(VME_WRITE,mpc_ram_adr,sndbuf,rcvbuf,NOW);
     //
     tmb_vme(VME_READ,mpc_ram_rdata_adr,sndbuf,rcvbuf,NOW);
     unsigned long int rlct11 = ((rcvbuf[0]&0xff)<<8) | (rcvbuf[1]&0xff) ;
     //
     sndbuf[0] = ((ramAdd)>>8)&0xff ;
-    sndbuf[1] = (ramAdd)&0xff | (0x1<<7) ;
+    sndbuf[1] = ((ramAdd)&0xff) | (0x1<<7) ;
     tmb_vme(VME_WRITE,mpc_ram_adr,sndbuf,rcvbuf,NOW);
     //
     tmb_vme(VME_READ,mpc_ram_rdata_adr,sndbuf,rcvbuf,NOW);
@@ -1286,7 +1286,7 @@ void TMB::FireMPCInjector(int nEvents){
   sndbuf[1] = nEvents & 0xff;
   tmb_vme(VME_WRITE,mpc_inj_adr,sndbuf,rcvbuf,NOW);
   //
-  sndbuf[0] = rcvbuf[0] & 0xfe | 0x1 ; // Fire injector
+  sndbuf[0] = (rcvbuf[0] & 0xfe) | 0x1 ; // Fire injector
   sndbuf[1] = nEvents & 0xff;
   tmb_vme(VME_WRITE,mpc_inj_adr,sndbuf,rcvbuf,NOW);
   //
@@ -1908,8 +1908,8 @@ void TMB::scope(int scp_arm,int scp_readout, int scp_channel) {
     for(itbin=0;itbin<256;itbin++) {                      //256 time bins per channel
       //
       ibit = ((scope_ram[itbin][iram]) >> (ich%16) ) & 1; //logic levels vs tbin for this chan	      
-      if(ibit == 0) scope_ch[itbin] = "_";       //display symbol for logic 0
-      if(ibit == 1) scope_ch[itbin] = "-";       //display symbol for logic 1
+      if(ibit == 0) scope_ch[itbin] = '_';       //display symbol for logic 0
+      if(ibit == 1) scope_ch[itbin] = '-';       //display symbol for logic 1
       (*MyOutput_) << scope_ch[itbin];
       //
       // Construct integer for special channel groups
@@ -3423,8 +3423,8 @@ void TMB::mpc_delay(unsigned short int time)
    printf("*** Inside.MPC delay %d \n", time);
    //
    printf("Reading address 0x86 to %x %x\n",rcvbuf[0]&0xff,rcvbuf[1]&0xff);
-   sndbuf[0] = (rcvbuf[0] & 0xfe | (time & 0x8)>>3) & 0xff;
-   sndbuf[1] = (rcvbuf[1] & 0x1f | (time & 0x7)<<5) & 0xff;
+   sndbuf[0] = ( (rcvbuf[0] & 0xfe) | ((time & 0x8)>>3) ) & 0xff;
+   sndbuf[1] = ( (rcvbuf[1] & 0x1f) | ((time & 0x7)<<5) ) & 0xff;
    printf("Setting address 0x86 to %x %x\n",sndbuf[0]&0xff,sndbuf[1]&0xff);
    tmb_vme(VME_WRITE,tmb_trig_adr,sndbuf,rcvbuf,NOW); // Write Trigger conf
    //
@@ -3434,7 +3434,7 @@ int TMB::GetWordCount(){
   //
   tmb_vme(VME_READ,dmb_wdcnt_adr,sndbuf,rcvbuf,NOW);
   //
-  return ( rcvbuf[1]&0xff | (rcvbuf[0]&0xf)>>8);
+  return ( (rcvbuf[1]&0xff) | ((rcvbuf[0]&0xf)>>8) );
   //
 }
 //
@@ -3854,9 +3854,9 @@ void TMB::UnjamFPGAMini() {
   //
   // Pick the chain according to bits [6:3].  Use the bootstrap register (bit[7]=1)
   const int tmb_mezz_chain  = 0x00a0;
-  const int alct_jtag_chain = 0x0080;
-  const int tmb_user_chain  = 0x00c0;
-  const int tmb_fpga_chain  = 0x00e0;
+  //SK: unused:  const int alct_jtag_chain = 0x0080;
+  //SK: unused:  const int tmb_user_chain  = 0x00c0;
+  //SK: unused:  const int tmb_fpga_chain  = 0x00e0;
   // read TMB boot register
   unsigned short int bootRegValue = 0;
   tmb_get_boot_reg(&bootRegValue);
@@ -9651,7 +9651,7 @@ int TMB::GetHotChannelDistripFromMap_(unsigned long int vme_address, int bit_in_
 int TMB::DCSreadAll(char *data) 
 {
   char out[2];
-  unsigned short tt, tr, sysm[6];
+  unsigned short tt, tr; //SK: unused: , sysm[6];
 
   if(checkvme_fail()) return 0;
   start(6,1);
@@ -9762,7 +9762,7 @@ int TMB::DCSvoltages(char *databuf)
      for(int i=6; i>=0; i--)
      {
          bits <<= 1;
-         bits |= (1-(adc_out[i]>>gtx_rx_link_good_bitlo)&1);  /* inverse bit: 0-good, 1-bad */
+         bits |= (1 - ((adc_out[i]>>gtx_rx_link_good_bitlo)&1) );  /* inverse bit: 0-good, 1-bad */
      }
      memcpy(databuf+total_chips*2, &bits, 2);
      extrabytes=2;

--- a/emuDCS/PeripheralCore/src/common/TMBTester.cc
+++ b/emuDCS/PeripheralCore/src/common/TMBTester.cc
@@ -657,7 +657,7 @@ bool TMBTester::testADC(){
 		      test1p5 &&
 		      testTcrit);
 
-  float adc_voltage[13];
+  float adc_voltage[14];
 
   tmb_->ADCvoltages(adc_voltage);
 

--- a/emuDCS/PeripheralCore/src/common/VMECC.cc
+++ b/emuDCS/PeripheralCore/src/common/VMECC.cc
@@ -1154,7 +1154,7 @@ void VMECC::prg_vcc_prom_ver(const char *path,const char *ver)
 	  std::cout << "Programming..." << std::endl;
           CNFG_ptr cp=read_crs();
           print_crs(cp);
-          if((cp->rst_misc & RST_CR_MSGLVL != RST_CR_MSGLVL) || (cp->ether & ETH_CR_SPONT != ETH_CR_SPONT)){
+          if( ( (cp->rst_misc & RST_CR_MSGLVL) != RST_CR_MSGLVL) || ( (cp->ether & ETH_CR_SPONT) != ETH_CR_SPONT)){
 	    std::cout << "Messages were not enabled; Will enable them now" << std::endl;
             set_clr_bits(SET, RST_MISC, RST_CR_MSGLVL);
             set_clr_bits(SET, ETHER, ETH_CR_SPONT);

--- a/emuDCS/PeripheralCore/src/common/VMEController_jtag.cc
+++ b/emuDCS/PeripheralCore/src/common/VMEController_jtag.cc
@@ -56,7 +56,7 @@ void VMEController::devdo(DEVTYPE dev,int ncmd,const char *cmd,int nbuf,const ch
   idev=geo[dev].jchan;
   }else{
     idev=idevo;
-    if(idev>4&idev!=11)return;
+    if(idev>4 && idev!=11)return;
   }
   // printf(" enter devdo %d %d \n",dev,idev);
   if (DEBUG) {
@@ -347,7 +347,7 @@ if(idev<=4||idev==11){
  case 3: /* jtag motherboard prom */
    if(ncmd==-99){sleep_vme(cmd);break;}   
    if(ncmd<0){RestoreIdle();break;}
-   if(ncmd>0&nbuf>0){
+   if(ncmd>0 && nbuf>0){
      scan(INSTR_REG,cmd2,ncmd2,outbuf,0);
    }else{
      scan(INSTR_REG,cmd2,ncmd2,outbuf,irdsnd);
@@ -1146,7 +1146,7 @@ unsigned int ptr;
    for(j=0;j<16;j++){
       ival=*data>>j;
       ival2=ival&0x01;
-      if(i!=byte-1|bit!=0|j!=15){
+      if(i!=byte-1 || bit!=0 || j!=15){
         if(ival2==0){vme_controller(1,ptr,x00,rcv);sdly();}
         if(ival2==1){vme_controller(1,ptr,x02,rcv);sdly();}
       }else{
@@ -1221,7 +1221,7 @@ unsigned int ptr;
    for(j=0;j<16;j++){
       ival=*data>>j;
       ival2=ival&0x01;
-      if(i!=byte-1|bit!=0|j!=15){
+      if(i!=byte-1 || bit!=0 || j!=15){
         if(ival2==0){vme_controller(1,ptr,x00,rcv);sdly();}
         if(ival2==1){vme_controller(1,ptr,x02,rcv);sdly();}
       }else{
@@ -1548,7 +1548,7 @@ void VMEController::new_devdo(DEVTYPE dev,int ncmd,const char *cmd,int nbuf,cons
   idev=geo[dev].jchan;
   }else{
     idev=idevo;
-    if(idev>4&idev!=11)return;
+    if(idev>4 && idev!=11)return;
   }
   // printf(" enter devdo %d %d \n",dev,idev);
 

--- a/emuDCS/PeripheralCore/src/common/VMEModule.cc
+++ b/emuDCS/PeripheralCore/src/common/VMEModule.cc
@@ -1424,7 +1424,7 @@ int VMEModule::read_mcs(char *binbuf, FILE *finp)
 {
    unsigned ext_add, loc_add, dsize, current_ext=0, current_add, index, i;
    char buf[1024], addbuf[5]={0,0,0,0,0}, lenbuf[3]={0,0,0};
-   int finish=0, segmented=0, lines=0, chksum, crc, n, c;
+   int finish=0, segmented=0, lines=0, chksum, crc, c; //SK: unused:, n;
    int total_read=0;
 
    rewind(finp);

--- a/emuDCS/PeripheralXtop/src/common/Chamber.cc
+++ b/emuDCS/PeripheralXtop/src/common/Chamber.cc
@@ -87,7 +87,7 @@ void Chamber::Fill(char *buffer, int source)
 //       ==1  from file
 //
    int idx=0, i;
-   char *start = buffer, *item, *sep = " ";
+   char *start = buffer, *item; const char *sep = " ";
    char *last=NULL;
    float y;
 
@@ -314,7 +314,7 @@ void Chamber::GetDimTEMP2(int hint, TEMP_2_DimBroker *dim_temp )
    if(type_<=1) return;
 
    int *info, this_st;
-   float *data, total_temp;
+   float *data; //SK: unused:, total_temp;
 
       info = &(states[0]);
       data = &(values[0]);

--- a/emuDCS/PeripheralXtop/src/common/DDU.cc
+++ b/emuDCS/PeripheralXtop/src/common/DDU.cc
@@ -38,7 +38,7 @@ void DDU::Fill(char *buffer, int source)
 //       ==1  from file
 //
    int idx=0, i;
-   char *start = buffer, *item, *sep = " ";
+   char *start = buffer, *item; const char *sep = " ";
    char *last=NULL;
    float y;
 


### PR DESCRIPTION
The cleanup was based on the regular compiler settings.
The build included the framework packages

```
        base \
        supervisor \
        soap \
        emuDCS/PeripheralCore \
        emuDCS/PeripheralApps \
        emuDCS/PeripheralXtop \
        emuDCS/OnlineDB \
        emuDCS/FEDCore \
        emuDCS/FEDUtils \
        emuDCS/FEDApps 
```

At some point in the future I will try to run code analysis with LLVM.

There is one type of warning remaining, to be passed to the developers
-  static void xgi::Utils::getPageHeader is deprecated new xgi::framework should be used instead

The following is a somewhat abbreviated summary of changes:
PeripheralCore
- ALCTController.cc 
  - GetSlowControlYear had a&b | c&d
  - GetSlowControlDay had a&b | c&d
- Crate.cc 
  - MonitorDMB unused variable Dversion
  - MonitorDCS unused variable Dversion Tversion
  - MonitorDCS2 unused variable chamber_on Tversion
- EMUjtag.cc  packCharBuffer had too few char output initialized to 0
- ALCTController::PrintStandbyRegister_ char buffer was too small (5 instead of 6, still below the mem alignments, so, was reading local function stack)
- TMBTester::testADC had internal temp array of voltages too short
- TMB.cc
  - 1241, 1248, 1259, 1266,1289 a&b | c
  - 1911,1912 "c" -> 'c' for correct char pickup
  - 3426,3427,3437 a&b | c&d
  - 3857-3859 unused variables
  - 9654 unused sysm
  - 9765 ()
- VMECC.cc
  - 1157 ()
- VMEController_jtag.cc
  - 59 "idev>4&idev!=11" -> &&
  - 350 ncmd>0 & nbuf>0 ==> &&
  - 1149,1224: "|" --> "||"
- VMEModule.cc
  - 1427 unused n

PeripheralApps
- ChamberUtilities.h
  - 147,173 order of data members
  - 211, 206 CFEBTiming_ConfigureLevel ConfigureTMB are not defined functions: removed
- ChamberUtilities.cc
  - 577 .. 602  initial_cfeb_phase initial_cfeb_posneg and more are unused
  - 906, 907,1146 uint vs int
  - 1112,1139,1176 "|" -> "||" (and "&&") logical expressions here, not bitwise 
  - 1216,1202,1203,1204, 1502, 1510, 1725, 1744 unused vars
  - 1570, 2315 uint vs int
  - 2555: in ::non_me11_wraparound_best_weighted_center "position" lookup issue in and out of for loop
    - "      iposition++; //SK: FIXME: WHY DO WE SKIP ONE HERE ??  "
  - 5451 ()
  - 2399, 2505 uninit var win_start (may have had  random numbers for bad inputs)
  - 1982 CFEBTiming_with_Posnegs_simple_routine uninits => "bad_cfeb_a=0, bad_cfeb_b=0, bad_cfeb=0 "
  - 2315 uints
- EmuPeripheralCrateConfig.cc
  - 5172 uint in loop
  - 6816 ()
  - 7755 uninit var
  - 7800 uint
- EmuPeripheralCrateConfig_VCC.cc
  - 633 ()
- EmuPeripheralCrateCommand 
  - read_test_config(const char*
- EmuCompareMcsFiles
  - const char\* temp_mcsname
- EmuPeripheralCrateMonitor
  - 1454 uninit pointer

PeripheralXtop
- Chamber
  - 90 const char*
  - 317 unused
- DDU
  - 41 const char*

FEDUtils
- DCCDebugger
  - 18, 40 ()
- DDUDebugger
  - 38,1417,1488,1542,1550,1707,1713

FEDApps
- EmuFCrateHyperDAQ
  - 1299,1311,4300,4301,4302,4315,4316,4317, 4622, 4623 ()
- Communicator
  - 991 ()

FEDCore
- DCC
  - 25: int16_t (explicit type around literals)
    base
- utils/DOM
  - 1085 in a switch add "default: break;" { only a subset of DOMNode kinds is handled }
